### PR TITLE
chore(ci): use pure-text Cargo.lock update via release-please extra-files

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,9 +14,6 @@ jobs:
   release-please:
     name: Create Release PR / Tag
     runs-on: ubuntu-latest
-    outputs:
-      release_created: ${{ steps.release.outputs.release_created }}
-      tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
       - name: Run release-please
         id: release
@@ -25,35 +22,3 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
-
-  # release-please 合并 PR 并打 tag 后，更新 Cargo.lock 使其与新版本一致
-  update-cargo-lock:
-    name: Update Cargo.lock after release
-    needs: release-please
-    if: needs.release-please.outputs.release_created == 'true'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - name: Checkout main
-        uses: actions/checkout@v4
-        with:
-          ref: main
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Cache cargo registry
-        uses: Swatinem/rust-cache@v2
-
-      - name: Update Cargo.lock to match new workspace version
-        run: cargo update --workspace
-
-      - name: Commit updated Cargo.lock
-        uses: stefanzweifel/git-auto-commit-action@v5
-        with:
-          commit_message: "chore: update Cargo.lock for ${{ needs.release-please.outputs.tag_name }}"
-          file_pattern: Cargo.lock
-          commit_user_name: "github-actions[bot]"
-          commit_user_email: "github-actions[bot]@users.noreply.github.com"

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -11,6 +11,27 @@
           "type": "toml",
           "path": "Cargo.toml",
           "jsonpath": "$.workspace.package.version"
+        },
+        "version.txt",
+        {
+          "type": "toml",
+          "path": "Cargo.lock",
+          "jsonpath": "$.package[?(@.name.value=='elizabeth-board')].version"
+        },
+        {
+          "type": "toml",
+          "path": "Cargo.lock",
+          "jsonpath": "$.package[?(@.name.value=='elizabeth-board-protocol')].version"
+        },
+        {
+          "type": "toml",
+          "path": "Cargo.lock",
+          "jsonpath": "$.package[?(@.name.value=='elizabeth-configrs')].version"
+        },
+        {
+          "type": "toml",
+          "path": "Cargo.lock",
+          "jsonpath": "$.package[?(@.name.value=='elizabeth-logrs')].version"
         }
       ]
     }


### PR DESCRIPTION
Bumps versions in Cargo.lock directly through release-please toml path extra-files config, removing the real-environment update-cargo-lock job.