### PR TITLE
chore(docker): rename image to elizabeth

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -25,7 +25,7 @@ on:
 permissions: {}
 
 env:
-  BACKEND_IMAGE: ${{ secrets.DOCKERHUB_USERNAME }}/elizabeth-backend
+  IMAGE: ${{ secrets.DOCKERHUB_USERNAME }}/elizabeth
 
 jobs:
   # ============================================================
@@ -53,10 +53,10 @@ jobs:
           echo "✅ Tag '$VERSION' exists."
 
   # ============================================================
-  # Job 1: 构建并推送 Backend 镜像
+  # Job 1: 构建并推送镜像
   # ============================================================
-  build-backend:
-    name: Build & Push Backend
+  build:
+    name: Build & Push
     runs-on: ubuntu-latest
     needs: validate
     permissions:
@@ -71,7 +71,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.BACKEND_IMAGE }}
+          images: ${{ env.IMAGE }}
           tags: |
             # 精确版本：v0.3.1 → 0.3.1
             type=semver,pattern={{version}},value=${{ github.event.inputs.version }}
@@ -92,7 +92,7 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Build and push backend image
+      - name: Build and push image
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -108,18 +108,19 @@ jobs:
   update-description:
     name: Update Docker Hub Description
     runs-on: ubuntu-latest
-    needs: [build-backend]
+    needs: [build]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.inputs.version }}
 
-      - name: Update backend description
+      - name: Update description
         uses: peter-evans/dockerhub-description@v4
+        continue-on-error: true
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-          repository: ${{ secrets.DOCKERHUB_USERNAME }}/elizabeth-backend
+          repository: ${{ secrets.DOCKERHUB_USERNAME }}/elizabeth
           readme-filepath: ./README.en.md
-          short-description: "Elizabeth Board - Single Port Embedded Application (Rust/Axum + Next.js SPA)"
+          short-description: "Elizabeth - File Sharing Platform (Rust/Axum + embedded Next.js SPA, single binary)"

--- a/docs/DEPLOYMENT_FULL.md
+++ b/docs/DEPLOYMENT_FULL.md
@@ -650,7 +650,7 @@ global:
   evaluation_interval: 15s
 
 scrape_configs:
-  - job_name: "elizabeth-backend"
+  - job_name: "elizabeth"
     static_configs:
       - targets: ["localhost:4092"]
     metrics_path: "/metrics"
@@ -846,7 +846,7 @@ ignoreregex =
 
 Ubuntu AppArmor 配置示例：
 
-`/etc/apparmor.d/elizabeth-backend`:
+`/etc/apparmor.d/elizabeth`:
 
 ```
 #include <tunables/global>
@@ -898,9 +898,9 @@ Internet → ALB → ECS Tasks (Elizabeth)
 aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin <account-id>.dkr.ecr.us-east-1.amazonaws.com
 
 # 构建并推送
-docker build -t elizabeth-backend -f Dockerfile.backend .
-docker tag elizabeth-backend:latest <account-id>.dkr.ecr.us-east-1.amazonaws.com/elizabeth-backend:latest
-docker push <account-id>.dkr.ecr.us-east-1.amazonaws.com/elizabeth-backend:latest
+docker build -t elizabeth -f Dockerfile.backend .
+docker tag elizabeth:latest <account-id>.dkr.ecr.us-east-1.amazonaws.com/elizabeth:latest
+docker push <account-id>.dkr.ecr.us-east-1.amazonaws.com/elizabeth:latest
 ```
 
 2. **创建 RDS 实例**
@@ -931,7 +931,7 @@ aws rds create-db-instance \
   "containerDefinitions": [
     {
       "name": "backend",
-      "image": "<account-id>.dkr.ecr.us-east-1.amazonaws.com/elizabeth-backend:latest",
+      "image": "<account-id>.dkr.ecr.us-east-1.amazonaws.com/elizabeth:latest",
       "portMappings": [{ "containerPort": 4092 }],
       "environment": [
         {
@@ -968,7 +968,7 @@ aws elbv2 create-load-balancer \
 
 # 创建目标组
 aws elbv2 create-target-group \
-  --name elizabeth-backend \
+  --name elizabeth \
   --protocol HTTP \
   --port 4092 \
   --vpc-id <vpc-id> \

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -56,7 +56,7 @@ mkdir -p "${BACKUP_DIR}"
 log_info "Starting backup: ${BACKUP_NAME}"
 
 # Check if containers are running
-if ! docker compose ps | grep -q "elizabeth-backend"; then
+if ! docker compose ps | grep -q "elizabeth"; then
     log_warn "Backend container is not running. Backup may be incomplete."
 fi
 


### PR DESCRIPTION
Rename Docker image from `elizabeth-backend` to `elizabeth`. Single binary serves API + SPA, the -backend suffix is no longer accurate.