### PR TITLE
fix(web): resolve room message overflow and ordered-list clipping

### DIFF
--- a/web/app/[roomName]/RoomClientPage.tsx
+++ b/web/app/[roomName]/RoomClientPage.tsx
@@ -507,7 +507,7 @@ export default function RoomPage() {
           </div>
         )
         : (
-          <div className="flex flex-1 overflow-hidden">
+          <div className="flex min-w-0 flex-1 overflow-hidden">
             <LeftSidebar />
             <MiddleColumn />
             <RightSidebar />

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -444,7 +444,18 @@
 
 .ProseMirror ol {
     list-style-type: decimal !important;
-    padding-left: 1.5em !important;
+    /*
+     * Ordered-list markers use the default outside positioning in both:
+     * 1) the composer preview/editor render path, and
+     * 2) the read-only Tiptap viewer used by saved messages.
+     *
+     * The previous 1.5em indent is enough for markers like `10.` / `19.`,
+     * but not for wider double-digit markers such as `20.` / `22.`.
+     * Because these ProseMirror surfaces also clip horizontal overflow,
+     * the leading digit gets cut off at the left edge.
+     */
+    padding-left: 2.75em !important;
+    padding-inline-start: 2.75em !important;
     margin-top: 0.5em !important;
     margin-bottom: 0.5em !important;
 }

--- a/web/components/chat/message-list.tsx
+++ b/web/components/chat/message-list.tsx
@@ -118,7 +118,7 @@ export function MessageList(
   }
 
   return (
-    <div className="flex flex-col overflow-hidden h-full">
+    <div className="flex h-full min-w-0 flex-col overflow-hidden">
       <div
         className={cn(
           "items-center justify-between border-b bg-muted/30 px-4 py-2",
@@ -158,12 +158,15 @@ export function MessageList(
         </div>
       </div>
 
-      <div className="relative flex-1 h-0" data-testid="message-list-scroll">
+      <div
+        className="relative h-0 min-w-0 flex-1"
+        data-testid="message-list-scroll"
+      >
         <ScrollArea
-          className="h-full p-4"
+          className="h-full min-w-0 p-4"
           ref={scrollRef}
         >
-          <div className="space-y-2 mx-2 mt-2">
+          <div className="mx-2 mt-2 min-w-0 space-y-2">
             {messages.length === 0
               ? (
                 <div className="flex h-full items-center justify-center">

--- a/web/components/layout/left-sidebar.tsx
+++ b/web/components/layout/left-sidebar.tsx
@@ -178,12 +178,16 @@ export function LeftSidebar() {
   // Desktop layout: fixed width with collapse functionality
   if (leftSidebarCollapsed) {
     return (
-      <div className="flex w-12 flex-col items-center border-r bg-muted/30 py-4">
+      <div
+        className="flex w-12 shrink-0 flex-col items-center border-r bg-muted/30 py-4"
+        data-testid="left-sidebar-collapsed-rail"
+      >
         <Button
           variant="ghost"
           size="icon"
           onClick={toggleLeftSidebar}
           title={t("sidebar.expandSidebar")}
+          data-testid="left-sidebar-expand"
         >
           <ChevronRight className="h-4 w-4" />
         </Button>
@@ -193,7 +197,10 @@ export function LeftSidebar() {
 
   return (
     <>
-      <aside className="flex w-80 flex-col border-r bg-muted/30 h-full overflow-hidden">
+      <aside
+        className="flex h-full w-80 shrink-0 flex-col overflow-hidden border-r bg-muted/30"
+        data-testid="left-sidebar"
+      >
         {/* Header */}
         <div className="flex h-12 items-center justify-between border-b px-4">
           <h2 className="font-semibold">{t("sidebar.roomControl")}</h2>
@@ -202,6 +209,7 @@ export function LeftSidebar() {
             size="icon"
             onClick={toggleLeftSidebar}
             title={t("sidebar.collapseSidebar")}
+            data-testid="left-sidebar-collapse"
           >
             <ChevronLeft className="h-4 w-4" />
           </Button>

--- a/web/components/layout/middle-column.tsx
+++ b/web/components/layout/middle-column.tsx
@@ -227,7 +227,7 @@ export function MiddleColumn() {
   };
 
   return (
-    <main className="flex flex-1 flex-col overflow-hidden">
+    <main className="flex min-w-0 flex-1 flex-col overflow-hidden">
       <Group orientation="vertical">
         {/* 消息列表面板 */}
         <Panel defaultSize={70} minSize={30}>

--- a/web/components/layout/right-sidebar.tsx
+++ b/web/components/layout/right-sidebar.tsx
@@ -308,8 +308,8 @@ export function RightSidebar() {
   return (
     <>
       <aside
-        className={`flex flex-col bg-muted/30 h-full overflow-hidden ${
-          isMobile ? "w-full" : "w-80 border-l"
+        className={`flex h-full flex-col overflow-hidden bg-muted/30 ${
+          isMobile ? "w-full" : "w-80 shrink-0 border-l"
         }`}
       >
         {/* Header */}

--- a/web/e2e/screenplay/room/screens/Room.screen.ts
+++ b/web/e2e/screenplay/room/screens/Room.screen.ts
@@ -84,6 +84,11 @@ export const RoomScreen = {
   messageListScroll: (page: Page): Locator =>
     page.getByTestId("message-list-scroll"),
 
+  messageListViewport: (page: Page): Locator =>
+    page.getByTestId("message-list-scroll").locator(
+      "[data-radix-scroll-area-viewport]",
+    ),
+
   messageSelectionToolbar: (page: Page): Locator =>
     page.getByTestId("message-selection-toolbar"),
 
@@ -101,6 +106,18 @@ export const RoomScreen = {
 
   roomConfigRoot: (page: Page): Locator =>
     page.locator("aside").first(),
+
+  leftSidebar: (page: Page): Locator =>
+    page.getByTestId("left-sidebar"),
+
+  leftSidebarCollapseButton: (page: Page): Locator =>
+    page.getByTestId("left-sidebar-collapse"),
+
+  leftSidebarExpandButton: (page: Page): Locator =>
+    page.getByTestId("left-sidebar-expand"),
+
+  leftSidebarCollapsedRail: (page: Page): Locator =>
+    page.getByTestId("left-sidebar-collapsed-rail"),
 
   roomConfigTitle: (page: Page): Locator =>
     page.locator("aside").first().getByText(tRoom("config.title")),

--- a/web/e2e/specs/room/message-overflow.spec.ts
+++ b/web/e2e/specs/room/message-overflow.spec.ts
@@ -20,7 +20,7 @@ test.describe("Message list layout and overflow", () => {
     await actor.attemptsTo(OpenRoom(room.url));
   });
 
-  test("long unbroken text does not overflow the message list width", async ({
+  test("long unbroken text stays inside the visible message list viewport when the room settings sidebar is expanded", async ({
     actor,
     page,
   }) => {
@@ -28,19 +28,24 @@ test.describe("Message list layout and overflow", () => {
     await actor.attemptsTo(SendMessage(longText));
     await actor.attemptsTo(SaveMessages());
 
-    const messageListScroll = RoomScreen.messageListScroll(page);
+    await expect(RoomScreen.leftSidebar(page)).toBeVisible();
+    await RoomScreen.leftSidebarCollapseButton(page).click();
+    await expect(RoomScreen.leftSidebarCollapsedRail(page)).toBeVisible();
+    await RoomScreen.leftSidebarExpandButton(page).click();
+    await expect(RoomScreen.leftSidebar(page)).toBeVisible();
+
+    const messageListViewport = RoomScreen.messageListViewport(page);
     const messageItem = RoomScreen.messageItems(page).last();
 
-    const listWidth = await messageListScroll.evaluate(
-      (el) => el.getBoundingClientRect().width,
-    );
-    const itemWidth = await messageItem.evaluate(
-      (el) => el.getBoundingClientRect().width,
-    );
+    const viewportBox = await messageListViewport.boundingBox();
+    const itemBox = await messageItem.boundingBox();
 
-    // Message item should not exceed the list container width
-    // Allow small tolerance for borders/padding
-    expect(itemWidth).toBeLessThanOrEqual(listWidth + 4);
+    expect(viewportBox).not.toBeNull();
+    expect(itemBox).not.toBeNull();
+    expect(itemBox!.x).toBeGreaterThanOrEqual(viewportBox!.x - 1);
+    expect(itemBox!.x + itemBox!.width).toBeLessThanOrEqual(
+      viewportBox!.x + viewportBox!.width + 1,
+    );
   });
 
   test("message content wraps properly with break-words", async ({
@@ -66,6 +71,100 @@ test.describe("Message list layout and overflow", () => {
 
     // Content scrollWidth should not exceed container width significantly
     expect(contentWidth).toBeLessThanOrEqual(containerWidth + 4);
+  });
+
+  test("ordered list markers in rendered messages keep 20+ items clear of the left edge", async ({
+    actor,
+    page,
+  }) => {
+    const orderedListMarkdown = Array.from(
+      { length: 24 },
+      (_, index) => `${index + 1}. Ordered item ${index + 1}`,
+    ).join("\n");
+
+    await RoomScreen.sourceModeButton(page).click();
+    await RoomScreen.sourceEditor(page).fill(orderedListMarkdown);
+    await RoomScreen.sendButton(page).click();
+    await actor.attemptsTo(SaveMessages());
+
+    const messageContent = RoomScreen.messageContents(page).last();
+    const twentiethItem = messageContent.locator(".ProseMirror ol > li").nth(19);
+
+    await expect(twentiethItem).toBeVisible();
+
+    const metrics = await twentiethItem.evaluate((element) => {
+      const firstTextNode = (() => {
+        const queue: Node[] = [element];
+        while (queue.length > 0) {
+          const current = queue.shift();
+          if (!current) break;
+          if (
+            current.nodeType === Node.TEXT_NODE &&
+            current.textContent?.trim()
+          ) {
+            return current as Text;
+          }
+          queue.unshift(...Array.from(current.childNodes));
+        }
+        return null;
+      })();
+
+      const range = document.createRange();
+      if (firstTextNode) {
+        range.setStart(firstTextNode, 0);
+        range.setEnd(firstTextNode, Math.min(1, firstTextNode.length));
+      } else {
+        range.selectNodeContents(element);
+      }
+
+      const messageContentElement = element.closest(
+        '[data-testid^="message-content-"]',
+      ) as HTMLElement | null;
+      const proseMirror = element.closest(".ProseMirror") as HTMLElement | null;
+      const textRect = range.getBoundingClientRect();
+      const list = element.parentElement as HTMLOListElement | null;
+      const listRect = list?.getBoundingClientRect();
+      const listStyle = list ? getComputedStyle(list) : getComputedStyle(element);
+      const itemStyle = getComputedStyle(element);
+      const fontSize = Number.parseFloat(itemStyle.fontSize) || 14;
+
+      const canvas = document.createElement("canvas");
+      const context = canvas.getContext("2d");
+      const markerText = "20.";
+      let markerWidth = fontSize;
+      let gapWidth = fontSize * 0.5;
+
+      if (context) {
+        context.font = itemStyle.font;
+        markerWidth = context.measureText(markerText).width;
+        gapWidth = Math.max(
+          context.measureText("  ").width,
+          fontSize * 0.5,
+        );
+      }
+
+      return {
+        estimatedMarkerLeft: textRect.left - markerWidth - gapWidth,
+        listPaddingLeft: Number.parseFloat(listStyle.paddingLeft),
+        messageContentLeft: messageContentElement?.getBoundingClientRect().left ?? 0,
+        proseMirrorLeft: proseMirror?.getBoundingClientRect().left ?? 0,
+        textOffsetLeftWithinList: listRect ? textRect.left - listRect.left : 0,
+        requiredIndent: markerWidth + gapWidth,
+      };
+    });
+
+    expect(metrics.listPaddingLeft).toBeGreaterThanOrEqual(
+      metrics.requiredIndent - 1,
+    );
+    expect(metrics.textOffsetLeftWithinList).toBeGreaterThanOrEqual(
+      metrics.requiredIndent - 1,
+    );
+    expect(metrics.estimatedMarkerLeft).toBeGreaterThanOrEqual(
+      metrics.proseMirrorLeft - 1,
+    );
+    expect(metrics.estimatedMarkerLeft).toBeGreaterThanOrEqual(
+      metrics.messageContentLeft - 1,
+    );
   });
 
   test("message meta row does not overflow the message card", async ({


### PR DESCRIPTION
- fix message items overflowing the visible list when the room settings sidebar is expanded
- preserve flex layout width constraints with min-w-0/shrink-0 on the room columns
- fix ProseMirror ordered-list indentation so 20+ markers are not clipped on the left in rendered messages
- replace the incorrect editor-preview regression with a rendered-message viewer regression test
- keep existing code-block coverage intact while validating the real #125 root cause

Refs: #124 #125