### PR TITLE
fix: wait longer for Docker image in 1Panel AppStore flow

### DIFF
--- a/.github/workflows/1panel-appstore.yml
+++ b/.github/workflows/1panel-appstore.yml
@@ -68,12 +68,12 @@ jobs:
         run: |
           set -euo pipefail
           image="${IMAGE}:${{ steps.version.outputs.version }}"
-          for attempt in $(seq 1 40); do
+          for attempt in $(seq 1 120); do
             if docker buildx imagetools inspect "${image}" >/dev/null 2>&1; then
               echo "Found ${image}"
               exit 0
             fi
-            if [[ "${attempt}" -eq 40 ]]; then
+            if [[ "${attempt}" -eq 120 ]]; then
               echo "Docker image was not published within the wait window: ${image}" >&2
               exit 1
             fi


### PR DESCRIPTION
## Summary
- Extend the 1Panel AppStore image wait window from 10 minutes (`40 × 15s`) to 30 minutes (`120 × 15s`).

## Why
`v1.5.0` Docker multi-arch publish took ~21 minutes. The tag-triggered 1Panel workflow timed out waiting for `yunique001/elizabeth:1.5.0`, then had to be re-dispatched after the image appeared.

## Verification
- Workflow syntax-only change; package smoke already green for 1.5.0 on re-dispatch: https://github.com/YuniqueUnic/elizabeth/actions/runs/29221272544