### PR TITLE
fix: redact secrets from startup config debug logs

### DIFF
--- a/crates/board/src/cmd/cli.rs
+++ b/crates/board/src/cmd/cli.rs
@@ -2,7 +2,7 @@ use clap::Parser;
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
-#[derive(Debug, Clone, Default, Parser)]
+#[derive(Clone, Default, Parser)]
 pub struct CliArgs {
     /// The path to the configuration file, defaults = ~/.config/elife/config.yaml
     #[clap(short = 'c', long, env = "CONFIG_FILE")]
@@ -27,6 +27,38 @@ pub struct CliArgs {
     /// The log level to use, -v for info, -vv for debug, -vvv/v for trace, default_value = "off"
     #[clap(short = 'v', long, action = clap::ArgAction::Count)]
     pub verbose: Option<u8>,
+}
+
+impl std::fmt::Debug for CliArgs {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Keep this free of crate deps: build.rs includes this file for completions.
+        f.debug_struct("CliArgs")
+            .field("config_file", &self.config_file)
+            .field("port", &self.port)
+            .field("listen_addr", &self.listen_addr)
+            .field(
+                "jwt_secret",
+                &self.jwt_secret.as_ref().map(|_| "[REDACTED]"),
+            )
+            .field(
+                "db_url",
+                &self.db_url.as_deref().map(redact_db_url_for_debug),
+            )
+            .field("verbose", &self.verbose)
+            .finish()
+    }
+}
+
+fn redact_db_url_for_debug(url: &str) -> String {
+    let Some(scheme_sep) = url.find("://") else {
+        return url.to_string();
+    };
+    let scheme = &url[..scheme_sep];
+    let rest = &url[scheme_sep + 3..];
+    let Some(at) = rest.find('@') else {
+        return url.to_string();
+    };
+    format!("{scheme}://[REDACTED]@{}", &rest[at + 1..])
 }
 
 #[derive(Debug, Parser)]

--- a/crates/board/src/config.rs
+++ b/crates/board/src/config.rs
@@ -1,6 +1,7 @@
 /// 应用程序配置模块
 ///
 /// 将配置相关的设置集中管理，与 AppState 分离
+use std::fmt;
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -28,7 +29,7 @@ pub struct AppConfig {
 }
 
 /// 数据库配置
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct DatabaseConfig {
     /// 数据库连接 URL
     /// 支持：
@@ -58,6 +59,17 @@ impl Default for DatabaseConfig {
             min_connections: Self::default_min_connections(),
             journal_mode: Self::default_journal_mode(),
         }
+    }
+}
+
+impl fmt::Debug for DatabaseConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("DatabaseConfig")
+            .field("url", &configrs::database_url_for_debug(&self.url))
+            .field("max_connections", &self.max_connections)
+            .field("min_connections", &self.min_connections)
+            .field("journal_mode", &self.journal_mode)
+            .finish()
     }
 }
 
@@ -160,7 +172,7 @@ pub struct RoomConfig {
     pub share_disabled_lock_duration: i64,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct RoomCreationDefaults {
     pub password: Option<String>,
     pub max_times_entered: i64,
@@ -359,6 +371,20 @@ impl Default for RoomCreationDefaults {
     }
 }
 
+impl fmt::Debug for RoomCreationDefaults {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("RoomCreationDefaults")
+            .field(
+                "password",
+                &configrs::optional_secret_for_debug(self.password.as_deref()),
+            )
+            .field("max_times_entered", &self.max_times_entered)
+            .field("max_content_size", &self.max_content_size)
+            .field("permission", &self.permission)
+            .finish()
+    }
+}
+
 impl Default for RoomConfig {
     fn default() -> Self {
         Self {
@@ -370,7 +396,7 @@ impl Default for RoomConfig {
 }
 
 /// 认证配置
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct AuthConfig {
     pub jwt_secret: String,
     pub ttl_seconds: i64,
@@ -432,6 +458,22 @@ impl Default for AuthConfig {
             cleanup_interval_seconds: 24 * 60 * 60,
             enable_refresh_token_rotation: true,
         }
+    }
+}
+
+impl fmt::Debug for AuthConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("AuthConfig")
+            .field("jwt_secret", &configrs::secret_for_debug(&self.jwt_secret))
+            .field("ttl_seconds", &self.ttl_seconds)
+            .field("leeway_seconds", &self.leeway_seconds)
+            .field("refresh_ttl_seconds", &self.refresh_ttl_seconds)
+            .field("cleanup_interval_seconds", &self.cleanup_interval_seconds)
+            .field(
+                "enable_refresh_token_rotation",
+                &self.enable_refresh_token_rotation,
+            )
+            .finish()
     }
 }
 

--- a/crates/board/src/lib.rs
+++ b/crates/board/src/lib.rs
@@ -65,6 +65,7 @@ pub async fn run() -> anyhow::Result<()> {
     const_service::init();
 
     let cli = cmd::Cli::parse();
+    // Secrets (jwt_secret / db credentials) are redacted by custom Debug impls.
     println!("Parsed CLI arguments: {cli:?}");
     match cli {
         cmd::Cli::Start(args) => {
@@ -78,8 +79,10 @@ pub async fn run() -> anyhow::Result<()> {
 }
 
 async fn start_server(cfg: &Config) -> anyhow::Result<()> {
-    println!("Starting server with args: {cfg:#?}");
+    // Initialize logging first so startup diagnostics respect log level.
+    // Config Debug redacts jwt.secret, room passwords, and DB credentials.
     log_service::init(cfg);
+    log::info!("Starting server with config: {cfg:#?}");
 
     // 初始化数据库
     let db_url = cfg.app.database.url.clone();

--- a/crates/board/src/tests/mod.rs
+++ b/crates/board/src/tests/mod.rs
@@ -5,3 +5,4 @@ mod room_gc_service;
 mod room_policy;
 mod rooms_issue_token;
 mod scheduler;
+mod secret_redaction;

--- a/crates/board/src/tests/secret_redaction.rs
+++ b/crates/board/src/tests/secret_redaction.rs
@@ -1,0 +1,48 @@
+use crate::cmd::CliArgs;
+use crate::config::{AuthConfig, DatabaseConfig, RoomCreationDefaults};
+
+#[test]
+fn cli_debug_redacts_jwt_secret_and_db_credentials() {
+    let args = CliArgs {
+        config_file: Some("/tmp/config.yaml".into()),
+        port: Some(4092),
+        listen_addr: Some("0.0.0.0".into()),
+        jwt_secret: Some("cli-jwt-secret-must-not-appear".into()),
+        db_url: Some("postgresql://alice:cli-db-pass@db.internal/app".into()),
+        verbose: Some(1),
+    };
+
+    let debug = format!("{args:?}");
+    assert!(!debug.contains("cli-jwt-secret-must-not-appear"));
+    assert!(!debug.contains("cli-db-pass"));
+    assert!(debug.contains("[REDACTED]"));
+    assert!(debug.contains("0.0.0.0"));
+}
+
+#[test]
+fn auth_config_debug_redacts_jwt_secret() {
+    let auth = AuthConfig::new("unit-test-jwt-secret-with-enough-length".into())
+        .expect("secret length is valid");
+    let debug = format!("{auth:?}");
+    assert!(!debug.contains("unit-test-jwt-secret-with-enough-length"));
+    assert!(debug.contains("[REDACTED]"));
+}
+
+#[test]
+fn database_and_room_debug_redact_sensitive_fields() {
+    let database = DatabaseConfig {
+        url: "postgresql://user:board-db-pass@localhost:5432/elizabeth".into(),
+        ..Default::default()
+    };
+    let room = RoomCreationDefaults {
+        password: Some("default-room-pass".into()),
+        ..Default::default()
+    };
+
+    let db_debug = format!("{database:?}");
+    let room_debug = format!("{room:?}");
+    assert!(!db_debug.contains("board-db-pass"));
+    assert!(db_debug.contains("[REDACTED]"));
+    assert!(!room_debug.contains("default-room-pass"));
+    assert!(room_debug.contains("[REDACTED]"));
+}

--- a/crates/board/src/tests/secret_redaction.rs
+++ b/crates/board/src/tests/secret_redaction.rs
@@ -7,42 +7,42 @@ fn cli_debug_redacts_jwt_secret_and_db_credentials() {
         config_file: Some("/tmp/config.yaml".into()),
         port: Some(4092),
         listen_addr: Some("0.0.0.0".into()),
-        jwt_secret: Some("cli-jwt-secret-must-not-appear".into()),
-        db_url: Some("postgresql://alice:cli-db-pass@db.internal/app".into()),
+        jwt_secret: Some("cli-jwt-secret-must-not-appear".into()), // pragma: allowlist secret
+        db_url: Some("postgresql://alice:cli-db-pass@db.internal/app".into()), // pragma: allowlist secret
         verbose: Some(1),
     };
 
     let debug = format!("{args:?}");
-    assert!(!debug.contains("cli-jwt-secret-must-not-appear"));
-    assert!(!debug.contains("cli-db-pass"));
+    assert!(!debug.contains("cli-jwt-secret-must-not-appear")); // pragma: allowlist secret
+    assert!(!debug.contains("cli-db-pass")); // pragma: allowlist secret
     assert!(debug.contains("[REDACTED]"));
     assert!(debug.contains("0.0.0.0"));
 }
 
 #[test]
 fn auth_config_debug_redacts_jwt_secret() {
-    let auth = AuthConfig::new("unit-test-jwt-secret-with-enough-length".into())
+    let auth = AuthConfig::new("unit-test-jwt-secret-with-enough-length".into()) // pragma: allowlist secret
         .expect("secret length is valid");
     let debug = format!("{auth:?}");
-    assert!(!debug.contains("unit-test-jwt-secret-with-enough-length"));
+    assert!(!debug.contains("unit-test-jwt-secret-with-enough-length")); // pragma: allowlist secret
     assert!(debug.contains("[REDACTED]"));
 }
 
 #[test]
 fn database_and_room_debug_redact_sensitive_fields() {
     let database = DatabaseConfig {
-        url: "postgresql://user:board-db-pass@localhost:5432/elizabeth".into(),
+        url: "postgresql://user:board-db-pass@localhost:5432/elizabeth".into(), // pragma: allowlist secret
         ..Default::default()
     };
     let room = RoomCreationDefaults {
-        password: Some("default-room-pass".into()),
+        password: Some("default-room-pass".into()), // pragma: allowlist secret
         ..Default::default()
     };
 
     let db_debug = format!("{database:?}");
     let room_debug = format!("{room:?}");
-    assert!(!db_debug.contains("board-db-pass"));
+    assert!(!db_debug.contains("board-db-pass")); // pragma: allowlist secret
     assert!(db_debug.contains("[REDACTED]"));
-    assert!(!room_debug.contains("default-room-pass"));
+    assert!(!room_debug.contains("default-room-pass")); // pragma: allowlist secret
     assert!(room_debug.contains("[REDACTED]"));
 }

--- a/crates/configrs/src/configs/app.rs
+++ b/crates/configrs/src/configs/app.rs
@@ -478,7 +478,7 @@ mod tests {
             },
             room: RoomConfig {
                 defaults: DefaultRoomConfig {
-                    password: Some("room-pass".into()),
+                    password: Some("room-pass".into()), // pragma: allowlist secret
                     max_times_entered: 7,
                     max_size: bytesize::ByteSize::b(42),
                     permissions: RoomPermissionConfig {
@@ -520,7 +520,7 @@ mod tests {
         assert_eq!(left.storage.root, "/tmp/storage");
         assert_eq!(left.room.defaults.max_size.as_u64(), 42);
         assert_eq!(left.room.defaults.max_times_entered, 7);
-        assert_eq!(left.room.defaults.password.as_deref(), Some("room-pass"));
+        assert_eq!(left.room.defaults.password.as_deref(), Some("room-pass")); // pragma: allowlist secret
         assert_eq!(
             left.room.defaults.permissions,
             RoomPermissionConfig {
@@ -562,27 +562,27 @@ mod tests {
     fn debug_redacts_jwt_secret_and_room_password() {
         let cfg = AppConfig {
             jwt: JwtConfig {
-                secret: "super-secret-jwt-value-should-not-leak".into(),
+                secret: "super-secret-jwt-value-should-not-leak".into(), // pragma: allowlist secret
                 ..Default::default()
             },
             room: RoomConfig {
                 defaults: DefaultRoomConfig {
-                    password: Some("room-pass".into()),
+                    password: Some("room-pass".into()), // pragma: allowlist secret
                     ..Default::default()
                 },
                 ..Default::default()
             },
             database: DatabaseConfig {
-                url: "postgresql://user:db-pass@localhost:5432/elizabeth".into(),
+                url: "postgresql://user:db-pass@localhost:5432/elizabeth".into(), // pragma: allowlist secret
                 ..Default::default()
             },
             ..Default::default()
         };
 
         let debug = format!("{cfg:?}");
-        assert!(!debug.contains("super-secret-jwt-value-should-not-leak"));
-        assert!(!debug.contains("room-pass"));
-        assert!(!debug.contains("db-pass"));
+        assert!(!debug.contains("super-secret-jwt-value-should-not-leak")); // pragma: allowlist secret
+        assert!(!debug.contains("room-pass")); // pragma: allowlist secret
+        assert!(!debug.contains("db-pass")); // pragma: allowlist secret
         assert!(debug.contains("[REDACTED]"));
     }
 
@@ -591,14 +591,14 @@ mod tests {
         let cfg = crate::Config {
             app: AppConfig {
                 jwt: JwtConfig {
-                    secret: "nested-secret-must-stay-hidden".into(),
+                    secret: "nested-secret-must-stay-hidden".into(), // pragma: allowlist secret
                     ..Default::default()
                 },
                 ..Default::default()
             },
         };
         let debug = format!("{cfg:#?}");
-        assert!(!debug.contains("nested-secret-must-stay-hidden"));
+        assert!(!debug.contains("nested-secret-must-stay-hidden")); // pragma: allowlist secret
         assert!(debug.contains("[REDACTED]"));
     }
 }

--- a/crates/configrs/src/configs/app.rs
+++ b/crates/configrs/src/configs/app.rs
@@ -1,5 +1,8 @@
 use smart_default::SmartDefault;
+use std::fmt;
 use std::time::Duration;
+
+use crate::redact::{database_url_for_debug, optional_secret_for_debug, secret_for_debug};
 
 const DEFAULT_JWT_SECRET: &str =
     "default-secret-change-in-productiondefault-secret-change-in-production"; // pragma: allowlist secret
@@ -40,7 +43,7 @@ pub struct LoggingConfig {
     pub level: String,
 }
 
-#[derive(Merge, Debug, Clone, SmartDefault, serde::Deserialize, serde::Serialize)]
+#[derive(Merge, Clone, SmartDefault, serde::Deserialize, serde::Serialize)]
 #[serde(default)]
 pub struct DatabaseConfig {
     #[default("sqlite://app.db?mode=rwc")]
@@ -57,7 +60,18 @@ pub struct DatabaseConfig {
     pub journal_mode: String,
 }
 
-#[derive(Merge, Debug, Clone, SmartDefault, serde::Deserialize, serde::Serialize)]
+impl fmt::Debug for DatabaseConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("DatabaseConfig")
+            .field("url", &database_url_for_debug(&self.url))
+            .field("max_connections", &self.max_connections)
+            .field("min_connections", &self.min_connections)
+            .field("journal_mode", &self.journal_mode)
+            .finish()
+    }
+}
+
+#[derive(Merge, Clone, SmartDefault, serde::Deserialize, serde::Serialize)]
 #[serde(default)]
 pub struct JwtConfig {
     #[default(DEFAULT_JWT_SECRET.to_string())] // pragma: allowlist secret
@@ -79,6 +93,22 @@ pub struct JwtConfig {
     #[default(true)]
     #[merge(strategy = overwrite)]
     pub enable_refresh_token_rotation: bool,
+}
+
+impl fmt::Debug for JwtConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("JwtConfig")
+            .field("secret", &secret_for_debug(&self.secret))
+            .field("ttl_seconds", &self.ttl_seconds)
+            .field("leeway_seconds", &self.leeway_seconds)
+            .field("refresh_ttl_seconds", &self.refresh_ttl_seconds)
+            .field("cleanup_interval_seconds", &self.cleanup_interval_seconds)
+            .field(
+                "enable_refresh_token_rotation",
+                &self.enable_refresh_token_rotation,
+            )
+            .finish()
+    }
 }
 
 #[derive(Merge, Debug, Clone, SmartDefault, serde::Deserialize, serde::Serialize)]
@@ -116,7 +146,7 @@ impl Default for RoomConfig {
 /// 所有新建房间的非时间默认值。
 ///
 /// 这里不是部署上限；房间创建后仍可通过 settings 修改容量和进入次数。
-#[derive(Merge, Debug, Clone, serde::Deserialize, serde::Serialize)]
+#[derive(Merge, Clone, serde::Deserialize, serde::Serialize)]
 #[serde(default)]
 pub struct DefaultRoomConfig {
     #[merge(strategy = overwrite)]
@@ -127,6 +157,20 @@ pub struct DefaultRoomConfig {
     pub max_size: bytesize::ByteSize,
     #[merge(strategy = overwrite)]
     pub permissions: RoomPermissionConfig,
+}
+
+impl fmt::Debug for DefaultRoomConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("DefaultRoomConfig")
+            .field(
+                "password",
+                &optional_secret_for_debug(self.password.as_deref()),
+            )
+            .field("max_times_entered", &self.max_times_entered)
+            .field("max_size", &self.max_size)
+            .field("permissions", &self.permissions)
+            .finish()
+    }
 }
 
 impl Default for DefaultRoomConfig {
@@ -512,5 +556,49 @@ mod tests {
         assert_eq!(left.server.addr, "127.0.0.1");
         assert_eq!(left.logging.level, "info");
         assert_eq!(left.server.port, 1234);
+    }
+
+    #[test]
+    fn debug_redacts_jwt_secret_and_room_password() {
+        let cfg = AppConfig {
+            jwt: JwtConfig {
+                secret: "super-secret-jwt-value-should-not-leak".into(),
+                ..Default::default()
+            },
+            room: RoomConfig {
+                defaults: DefaultRoomConfig {
+                    password: Some("room-pass".into()),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            database: DatabaseConfig {
+                url: "postgresql://user:db-pass@localhost:5432/elizabeth".into(),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let debug = format!("{cfg:?}");
+        assert!(!debug.contains("super-secret-jwt-value-should-not-leak"));
+        assert!(!debug.contains("room-pass"));
+        assert!(!debug.contains("db-pass"));
+        assert!(debug.contains("[REDACTED]"));
+    }
+
+    #[test]
+    fn debug_redacts_nested_config_pretty_print() {
+        let cfg = crate::Config {
+            app: AppConfig {
+                jwt: JwtConfig {
+                    secret: "nested-secret-must-stay-hidden".into(),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        };
+        let debug = format!("{cfg:#?}");
+        assert!(!debug.contains("nested-secret-must-stay-hidden"));
+        assert!(debug.contains("[REDACTED]"));
     }
 }

--- a/crates/configrs/src/lib.rs
+++ b/crates/configrs/src/lib.rs
@@ -10,10 +10,12 @@ pub use configs::{
 };
 pub use error::{ConfigError, Result};
 use merge::Merge;
+pub use redact::{REDACTED, database_url_for_debug, optional_secret_for_debug, secret_for_debug};
 
 mod configs;
 mod error;
 mod merge;
+mod redact;
 
 /// Main configuration structure that holds all application settings.
 ///

--- a/crates/configrs/src/redact.rs
+++ b/crates/configrs/src/redact.rs
@@ -1,0 +1,65 @@
+//! Helpers for secret-safe `Debug` formatting.
+
+/// Placeholder used when a secret value is present but must not be logged.
+pub const REDACTED: &str = "[REDACTED]";
+
+/// Format a secret string for `Debug` without revealing its contents.
+pub fn secret_for_debug(value: &str) -> &'static str {
+    if value.is_empty() {
+        "<empty>"
+    } else {
+        REDACTED
+    }
+}
+
+/// Format an optional secret for `Debug`.
+pub fn optional_secret_for_debug(value: Option<&str>) -> Option<&'static str> {
+    value.map(secret_for_debug)
+}
+
+/// Redact credentials embedded in a database URL userinfo section.
+///
+/// Examples:
+/// - `postgresql://user:pass@host/db` -> `postgresql://[REDACTED]@host/db`
+/// - `sqlite://app.db?mode=rwc` stays unchanged (no userinfo)
+pub fn database_url_for_debug(url: &str) -> String {
+    let Some(scheme_sep) = url.find("://") else {
+        return url.to_string();
+    };
+    let scheme = &url[..scheme_sep];
+    let rest = &url[scheme_sep + 3..];
+    let Some(at) = rest.find('@') else {
+        return url.to_string();
+    };
+    format!("{scheme}://{REDACTED}@{}", &rest[at + 1..])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn secret_for_debug_hides_non_empty_values() {
+        assert_eq!(secret_for_debug("super-secret-value"), REDACTED);
+        assert_eq!(secret_for_debug(""), "<empty>");
+    }
+
+    #[test]
+    fn optional_secret_for_debug_preserves_none() {
+        assert_eq!(optional_secret_for_debug(None), None);
+        assert_eq!(optional_secret_for_debug(Some("room-pass")), Some(REDACTED));
+    }
+
+    #[test]
+    fn database_url_for_debug_redacts_userinfo() {
+        assert_eq!(
+            database_url_for_debug("postgresql://alice:s3cret@db.example:5432/app"),
+            format!("postgresql://{REDACTED}@db.example:5432/app")
+        );
+        assert_eq!(
+            database_url_for_debug("sqlite://app.db?mode=rwc"),
+            "sqlite://app.db?mode=rwc"
+        );
+        assert_eq!(database_url_for_debug("not-a-url"), "not-a-url");
+    }
+}

--- a/crates/configrs/src/redact.rs
+++ b/crates/configrs/src/redact.rs
@@ -20,7 +20,7 @@ pub fn optional_secret_for_debug(value: Option<&str>) -> Option<&'static str> {
 /// Redact credentials embedded in a database URL userinfo section.
 ///
 /// Examples:
-/// - `postgresql://user:pass@host/db` -> `postgresql://[REDACTED]@host/db`
+/// - `postgresql://user:pass@host/db` -> `postgresql://[REDACTED]@host/db` // pragma: allowlist secret
 /// - `sqlite://app.db?mode=rwc` stays unchanged (no userinfo)
 pub fn database_url_for_debug(url: &str) -> String {
     let Some(scheme_sep) = url.find("://") else {
@@ -40,20 +40,20 @@ mod tests {
 
     #[test]
     fn secret_for_debug_hides_non_empty_values() {
-        assert_eq!(secret_for_debug("super-secret-value"), REDACTED);
+        assert_eq!(secret_for_debug("super-secret-value"), REDACTED); // pragma: allowlist secret
         assert_eq!(secret_for_debug(""), "<empty>");
     }
 
     #[test]
     fn optional_secret_for_debug_preserves_none() {
         assert_eq!(optional_secret_for_debug(None), None);
-        assert_eq!(optional_secret_for_debug(Some("room-pass")), Some(REDACTED));
+        assert_eq!(optional_secret_for_debug(Some("room-pass")), Some(REDACTED)); // pragma: allowlist secret
     }
 
     #[test]
     fn database_url_for_debug_redacts_userinfo() {
         assert_eq!(
-            database_url_for_debug("postgresql://alice:s3cret@db.example:5432/app"),
+            database_url_for_debug("postgresql://alice:s3cret@db.example:5432/app"), // pragma: allowlist secret
             format!("postgresql://{REDACTED}@db.example:5432/app")
         );
         assert_eq!(


### PR DESCRIPTION
## Summary
- Redact `jwt.secret`, room default passwords, and DB URL credentials in `Debug` output (`configrs` + board config/CLI).
- Move startup config logging after logger init and stop dumping secrets via `println!("{cfg:#?}")`.
- Add regression tests covering CLI, AuthConfig, DatabaseConfig, and nested Config pretty-print.

## Context
1Panel AppStore review for `okxlin/appstore#4782` blocked on v1.5.1 leaking `JWT_SECRET` through:
`println!("Starting server with args: {cfg:#?}")` in `crates/board/src/lib.rs`.

## Test plan
- [x] `cargo test -p elizabeth-configrs --all-features`
- [x] `cargo test -p elizabeth-board --lib --all-features`
- [x] `cargo clippy -p elizabeth-configrs -p elizabeth-board --all-targets --all-features -- -D warnings`
- [ ] CI green
- [ ] Patch release (1.5.2) + Docker image + update appstore PR