### PR TITLE
fix(board): stage chunk uploads on durable storage

### DIFF
--- a/crates/board/src/chunk_temp_storage.rs
+++ b/crates/board/src/chunk_temp_storage.rs
@@ -1,23 +1,26 @@
 use std::io;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
-pub fn reservation_dir(reservation_id: i64) -> PathBuf {
-    std::env::temp_dir()
-        .join("elizabeth")
-        .join("chunks")
-        .join(reservation_id.to_string())
+/// Keep chunk staging on the configured storage filesystem so completing an
+/// upload can atomically rename the verified file into its room directory.
+pub fn staging_root(storage_root: &Path) -> PathBuf {
+    storage_root.join(".chunks")
 }
 
-pub fn chunk_path(reservation_id: i64, chunk_index: i64) -> PathBuf {
-    reservation_dir(reservation_id).join(format!("chunk_{chunk_index}"))
+pub fn reservation_dir(storage_root: &Path, reservation_id: i64) -> PathBuf {
+    staging_root(storage_root).join(reservation_id.to_string())
 }
 
-pub fn merged_file_path(reservation_id: i64) -> PathBuf {
-    reservation_dir(reservation_id).join("merged_file")
+pub fn chunk_path(storage_root: &Path, reservation_id: i64, chunk_index: i64) -> PathBuf {
+    reservation_dir(storage_root, reservation_id).join(format!("chunk_{chunk_index}"))
 }
 
-pub async fn remove_reservation_dir(reservation_id: i64) -> io::Result<()> {
-    match tokio::fs::remove_dir_all(reservation_dir(reservation_id)).await {
+pub fn merged_file_path(storage_root: &Path, reservation_id: i64) -> PathBuf {
+    reservation_dir(storage_root, reservation_id).join("merged_file")
+}
+
+pub async fn remove_reservation_dir(storage_root: &Path, reservation_id: i64) -> io::Result<()> {
+    match tokio::fs::remove_dir_all(reservation_dir(storage_root, reservation_id)).await {
         Ok(()) => Ok(()),
         Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
         Err(error) => Err(error),

--- a/crates/board/src/handlers/chunked_upload.rs
+++ b/crates/board/src/handlers/chunked_upload.rs
@@ -351,7 +351,10 @@ pub async fn cancel_chunked_upload(
     }
 
     // 清理临时分块文件
-    if let Err(e) = crate::chunk_temp_storage::remove_reservation_dir(reservation_id).await {
+    if let Err(e) =
+        crate::chunk_temp_storage::remove_reservation_dir(app_state.storage_root(), reservation_id)
+            .await
+    {
         logrs::error!("清理临时分块文件失败：{}", e);
     }
 

--- a/crates/board/src/handlers/chunked_upload/complete.rs
+++ b/crates/board/src/handlers/chunked_upload/complete.rs
@@ -82,10 +82,13 @@ pub async fn complete_file_merge(
         reservation.total_chunks,
     )
     .await?;
-    let final_file_path = crate::chunk_temp_storage::merged_file_path(reservation_db_id);
+    let storage_root = app_state.storage_root();
+    let final_file_path =
+        crate::chunk_temp_storage::merged_file_path(storage_root, reservation_db_id);
 
     merge_and_verify_chunks(
         &sorted_chunks,
+        storage_root,
         &final_file_path,
         &payload.final_hash,
         &reservation_repository,
@@ -95,7 +98,7 @@ pub async fn complete_file_merge(
 
     let file_manifest = parse_file_manifest(&reservation.file_manifest)?;
     let file = first_manifest_file(&file_manifest)?;
-    let storage_dir = app_state.storage_root().join(room_id.to_string());
+    let storage_dir = storage_root.join(room_id.to_string());
     fs::create_dir_all(&storage_dir)
         .await
         .map_err(|e| AppError::internal(format!("创建存储目录失败：{}", e)))?;
@@ -120,7 +123,7 @@ pub async fn complete_file_merge(
         .await
         .map_err(|e| AppError::internal(format!("更新上传状态失败：{}", e)))?;
 
-    cleanup_temp_dir(reservation_db_id).await;
+    cleanup_temp_dir(storage_root, reservation_db_id).await;
 
     let content_repository = RoomContentRepository::new(app_state.db_pool.clone());
     let created_content =
@@ -223,12 +226,13 @@ fn validate_uploaded_chunks(chunks: &[RoomChunkUpload], total_chunks: i64) -> Re
 
 async fn merge_and_verify_chunks(
     chunks: &[RoomChunkUpload],
+    storage_root: &StdPath,
     final_file_path: &StdPath,
     final_hash: &str,
     repository: &RoomUploadReservationRepository,
     reservation_id: i64,
 ) -> Result<(), AppError> {
-    if let Err(e) = merge_chunks(chunks, final_file_path).await {
+    if let Err(e) = merge_chunks(chunks, storage_root, final_file_path).await {
         mark_upload_failed(repository, reservation_id).await;
         return Err(AppError::internal(format!("文件合并失败：{}", e)));
     }
@@ -342,21 +346,27 @@ fn build_room_content(
     }
 }
 
-async fn cleanup_temp_dir(reservation_id: i64) {
-    if let Err(e) = crate::chunk_temp_storage::remove_reservation_dir(reservation_id).await {
+async fn cleanup_temp_dir(storage_root: &StdPath, reservation_id: i64) {
+    if let Err(e) =
+        crate::chunk_temp_storage::remove_reservation_dir(storage_root, reservation_id).await
+    {
         logrs::error!("清理临时文件失败：{}", e);
     }
 }
 
 async fn merge_chunks(
     chunks: &[RoomChunkUpload],
+    storage_root: &StdPath,
     output_path: &StdPath,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let mut output_file = fs::File::create(output_path).await?;
 
     for chunk in chunks {
-        let chunk_path =
-            crate::chunk_temp_storage::chunk_path(chunk.reservation_id, chunk.chunk_index);
+        let chunk_path = crate::chunk_temp_storage::chunk_path(
+            storage_root,
+            chunk.reservation_id,
+            chunk.chunk_index,
+        );
         let mut chunk_file = fs::File::open(&chunk_path).await?;
 
         let mut buffer = vec![0u8; chunk.chunk_size as usize];

--- a/crates/board/src/handlers/chunked_upload/upload.rs
+++ b/crates/board/src/handlers/chunked_upload/upload.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{path::Path as StdPath, sync::Arc};
 
 use axum::{
     Json,
@@ -77,7 +77,13 @@ pub async fn upload_chunk(
     ensure_chunk_slot_empty(&chunk_repository, reservation_id, parsed.chunk_index).await?;
 
     let calculated_hash = validate_chunk_hash(&parsed)?;
-    write_chunk_file(reservation_id, parsed.chunk_index, &parsed.chunk_data).await?;
+    write_chunk_file(
+        app_state.storage_root(),
+        reservation_id,
+        parsed.chunk_index,
+        &parsed.chunk_data,
+    )
+    .await?;
     persist_chunk_record(
         &chunk_repository,
         &reservation_repository,
@@ -228,16 +234,18 @@ fn validate_chunk_hash(parsed: &ParsedChunkUpload) -> Result<String, AppError> {
 }
 
 async fn write_chunk_file(
+    storage_root: &StdPath,
     reservation_id: i64,
     chunk_index: i32,
     chunk_data: &[u8],
 ) -> Result<(), AppError> {
-    let temp_dir = crate::chunk_temp_storage::reservation_dir(reservation_id);
+    let temp_dir = crate::chunk_temp_storage::reservation_dir(storage_root, reservation_id);
     fs::create_dir_all(&temp_dir)
         .await
         .map_err(|e| AppError::internal(format!("创建临时目录失败：{}", e)))?;
 
-    let chunk_file_path = crate::chunk_temp_storage::chunk_path(reservation_id, chunk_index.into());
+    let chunk_file_path =
+        crate::chunk_temp_storage::chunk_path(storage_root, reservation_id, chunk_index.into());
     let mut file = fs::File::create(&chunk_file_path)
         .await
         .map_err(|e| AppError::internal(format!("创建分块文件失败：{}", e)))?;

--- a/crates/board/src/lib.rs
+++ b/crates/board/src/lib.rs
@@ -375,7 +375,10 @@ fn start_scheduler(
         TaskRegistration {
             interval: room_interval,
             timeout,
-            task: Arc::new(UploadCleanupTask::new(upload_repository)),
+            task: Arc::new(UploadCleanupTask::new(
+                upload_repository,
+                app_state.storage_root().clone(),
+            )),
         },
     ];
     registrations.extend(

--- a/crates/board/src/tasks/upload_cleanup.rs
+++ b/crates/board/src/tasks/upload_cleanup.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{path::PathBuf, sync::Arc};
 
 use anyhow::Result;
 use async_trait::async_trait;
@@ -8,11 +8,15 @@ use crate::scheduler::{ScheduledTask, ScheduledTaskId, TaskRunReport};
 
 pub struct UploadCleanupTask {
     repository: Arc<RoomUploadReservationRepository>,
+    storage_root: PathBuf,
 }
 
 impl UploadCleanupTask {
-    pub fn new(repository: Arc<RoomUploadReservationRepository>) -> Self {
-        Self { repository }
+    pub fn new(repository: Arc<RoomUploadReservationRepository>, storage_root: PathBuf) -> Self {
+        Self {
+            repository,
+            storage_root,
+        }
     }
 }
 
@@ -25,7 +29,8 @@ impl ScheduledTask for UploadCleanupTask {
     async fn run(&self) -> Result<TaskRunReport> {
         let chunked_ids = self.repository.list_expired_chunked_ids().await?;
         for reservation_id in chunked_ids {
-            crate::chunk_temp_storage::remove_reservation_dir(reservation_id).await?;
+            crate::chunk_temp_storage::remove_reservation_dir(&self.storage_root, reservation_id)
+                .await?;
         }
         let changed = self.repository.purge_expired().await?;
         Ok(TaskRunReport {

--- a/crates/board/src/tests/chunk_temp_storage.rs
+++ b/crates/board/src/tests/chunk_temp_storage.rs
@@ -1,0 +1,22 @@
+use std::path::Path;
+
+#[test]
+fn chunk_staging_paths_are_scoped_to_the_configured_storage_root() {
+    let storage_root = Path::new("/srv/elizabeth/storage/rooms");
+    let reservation_id = 42;
+    let reservation_dir = crate::chunk_temp_storage::reservation_dir(storage_root, reservation_id);
+
+    assert_eq!(
+        crate::chunk_temp_storage::staging_root(storage_root),
+        storage_root.join(".chunks")
+    );
+    assert_eq!(reservation_dir, storage_root.join(".chunks/42"));
+    assert_eq!(
+        crate::chunk_temp_storage::chunk_path(storage_root, reservation_id, 3),
+        reservation_dir.join("chunk_3")
+    );
+    assert_eq!(
+        crate::chunk_temp_storage::merged_file_path(storage_root, reservation_id),
+        reservation_dir.join("merged_file")
+    );
+}

--- a/crates/board/src/tests/mod.rs
+++ b/crates/board/src/tests/mod.rs
@@ -1,4 +1,5 @@
 mod cfg_service;
+mod chunk_temp_storage;
 mod db;
 mod room_expiry;
 mod room_gc_service;

--- a/crates/board/src/tests/room_policy.rs
+++ b/crates/board/src/tests/room_policy.rs
@@ -471,11 +471,14 @@ async fn upload_cleanup_removes_expired_chunk_files_before_database_rows() -> an
     .execute(&*state.db_pool)
     .await?;
 
-    let chunk_dir = crate::chunk_temp_storage::reservation_dir(reservation_id);
+    let chunk_dir =
+        crate::chunk_temp_storage::reservation_dir(state.storage_root(), reservation_id);
     tokio::fs::create_dir_all(&chunk_dir).await?;
     tokio::fs::write(chunk_dir.join("chunk_0"), b"orphaned").await?;
 
-    let report = UploadCleanupTask::new(repository.clone()).run().await?;
+    let report = UploadCleanupTask::new(repository.clone(), state.storage_root().clone())
+        .run()
+        .await?;
     assert_eq!(report.changed, 1);
     assert!(!tokio::fs::try_exists(&chunk_dir).await?);
     assert!(repository.fetch_by_id(reservation_id).await?.is_none());

--- a/crates/board/tests/chunked_upload_tests.rs
+++ b/crates/board/tests/chunked_upload_tests.rs
@@ -77,7 +77,7 @@ fn single_chunk_request(
 /// 测试基本的分块上传流程
 #[tokio::test]
 async fn test_chunked_upload_complete_workflow() -> Result<()> {
-    let (app, _pool) = create_test_app().await?;
+    let (app, pool) = create_test_app().await?;
 
     let room_name = "chunked_upload_test_room";
 
@@ -198,8 +198,12 @@ async fn test_chunked_upload_complete_workflow() -> Result<()> {
         sqlx::query_scalar("SELECT path FROM room_contents WHERE id = $1 AND room_id = (SELECT id FROM rooms WHERE name = $2)")
             .bind(content_id)
             .bind(room_name)
-            .fetch_one(_pool.as_ref())
+            .fetch_one(pool.as_ref())
             .await?;
+    let storage_root = std::path::Path::new(&stored_path)
+        .parent()
+        .and_then(|room_storage_dir| room_storage_dir.parent())
+        .expect("final path should be nested below the storage root");
     assert!(
         stored_path.starts_with(std::env::temp_dir().to_string_lossy().as_ref()),
         "stored path should honor configured storage root, got {stored_path}"
@@ -207,6 +211,11 @@ async fn test_chunked_upload_complete_workflow() -> Result<()> {
     assert!(
         tokio::fs::try_exists(&stored_path).await?,
         "merged file should exist at configured storage root"
+    );
+    assert_eq!(tokio::fs::read(&stored_path).await?, file_data.as_bytes());
+    assert!(
+        !tokio::fs::try_exists(storage_root.join(".chunks").join(&reservation_id)).await?,
+        "completed uploads should remove their durable staging directory"
     );
 
     Ok(())


### PR DESCRIPTION
## Summary

- stage chunk uploads under the configured storage root instead of container `/tmp`
- keep merged files and room files on the same filesystem so completion uses an atomic rename
- clean durable staging on completion, cancellation, and expiry; add regression coverage for paths, cleanup, and the API workflow

## Production incident

The deployed container used `/tmp` on tmpfs and `/app/storage` on a Docker volume. Completing an upload attempted a cross-device rename, which fails with `EXDEV`.

## Verification

- `cargo fmt --all --check`
- `cargo check --workspace --all-targets --all-features`
- `cargo test --workspace --all-targets --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo build --workspace --all-targets --all-features --release`
- Rust size gate for `crates/board/src/**/*.rs`