### PR TITLE
fix(identity): handle rooms without expiry for admin identity codes

### DIFF
--- a/crates/board/src/handlers/rooms/identity_codes.rs
+++ b/crates/board/src/handlers/rooms/identity_codes.rs
@@ -314,9 +314,10 @@ fn identity_code_expiry(
                 "admin identity code expiry follows the room lifetime",
             ));
         }
-        return room
+        // Rooms without expiry get a far-future admin code (100 years).
+        return Ok(room
             .expire_at
-            .ok_or_else(|| AppError::internal("Room has no expiry for admin identity code"));
+            .unwrap_or_else(|| Utc::now().naive_utc() + Duration::days(365 * 100)));
     }
     let seconds =
         requested_secs.unwrap_or_else(|| app_state.token_service().get_ttl().num_seconds());


### PR DESCRIPTION
Rooms with no expire_at previously returned 500 when creating admin identity codes. Use a far-future date (100 years) instead of failing.

Release-As: 1.8.2