### PR TITLE
feat(seo): serve robots.txt and X-Robots-Tag driven by indexing policy

### DIFF
--- a/crates/board/src/init/cfg_service/env_overrides.rs
+++ b/crates/board/src/init/cfg_service/env_overrides.rs
@@ -245,6 +245,11 @@ fn apply_security_env_overrides(cfg: &mut configrs::Config) {
         "MIDDLEWARE_SECURITY_REFERRER_POLICY",
         cfg.app.middleware.security.referrer_policy
     );
+    apply_env!(
+        env_bool,
+        "MIDDLEWARE_SECURITY_DISALLOW_SEARCH_INDEXING",
+        cfg.app.middleware.security.disallow_search_indexing
+    );
 }
 
 fn apply_rate_limit_env_overrides(cfg: &mut configrs::Config) {

--- a/crates/board/src/lib.rs
+++ b/crates/board/src/lib.rs
@@ -257,6 +257,21 @@ fn build_api_router(
     let ws_router = route::ws::api_router(app_state.clone());
     let router = router.merge(ws_router);
 
+    // 搜索引擎索引策略（默认防索引）：robots.txt 显式声明，HTML 响应附加 X-Robots-Tag
+    let disallow_search_indexing = cfg.app.middleware.security.disallow_search_indexing;
+    let router = router.route(
+        "/robots.txt",
+        axum::routing::get(move || async move {
+            (
+                [(
+                    axum::http::header::CONTENT_TYPE,
+                    "text/plain; charset=utf-8",
+                )],
+                robots_txt_body(disallow_search_indexing),
+            )
+        }),
+    );
+
     // Apply middleware configuration
     let middleware_config = crate::middleware::from_app_config(cfg);
     let middleware = crate::middleware::apply(&middleware_config, router)?;
@@ -265,9 +280,21 @@ fn build_api_router(
     // - 精确匹配静态文件（_next/*, favicon.ico 等）→ 直接返回
     // - /api/* 路径 → JSON 404（防止穿透到 SPA）
     // - 所有其他路径 → 返回 index.html（由客户端 React Router 接管）
-    let router = middleware.router.fallback(spa_fallback);
+    let router = middleware
+        .router
+        .fallback(move |request| spa_fallback(request, disallow_search_indexing));
 
     Ok((scalar_path, router, middleware.scheduled_tasks))
+}
+
+/// robots.txt 内容：防索引开启时拒绝全部爬虫，关闭时显式放行
+/// （避免关闭时 /robots.txt 落入 SPA fallback 返回 HTML）。
+fn robots_txt_body(disallow_search_indexing: bool) -> &'static str {
+    if disallow_search_indexing {
+        "User-agent: *\nDisallow: /\n"
+    } else {
+        "User-agent: *\nAllow: /\n"
+    }
 }
 
 /// Next.js `output: 'export'` 产物目录，由 rust-embed 在编译期打包进二进制
@@ -279,7 +306,7 @@ fn build_api_router(
 struct EmbeddedSpa;
 
 /// SPA Fallback Handler（极简三步逻辑）
-async fn spa_fallback(request: Request<Body>) -> Response {
+async fn spa_fallback(request: Request<Body>, disallow_search_indexing: bool) -> Response {
     let path = request.uri().path().trim_start_matches('/').to_string();
 
     // Step 1：防御拦截 API 路由 — /api/* 绝不降级为 HTML
@@ -315,23 +342,32 @@ async fn spa_fallback(request: Request<Body>) -> Response {
         "_.html"
     };
 
-    serve_html_asset(fallback_file)
+    serve_html_asset(fallback_file, disallow_search_indexing)
 }
 
-fn serve_html_asset(name: &str) -> Response {
+fn serve_html_asset(name: &str, disallow_search_indexing: bool) -> Response {
     match EmbeddedSpa::get(name) {
-        Some(html) => Response::builder()
-            .status(StatusCode::OK)
-            .header(
-                axum::http::header::CONTENT_TYPE,
-                HeaderValue::from_static("text/html; charset=utf-8"),
-            )
-            .header(
-                axum::http::header::CACHE_CONTROL,
-                HeaderValue::from_static("no-store, max-age=0"),
-            )
-            .body(Body::from(html.data))
-            .unwrap_or_else(|_| StatusCode::INTERNAL_SERVER_ERROR.into_response()),
+        Some(html) => {
+            let mut builder = Response::builder()
+                .status(StatusCode::OK)
+                .header(
+                    axum::http::header::CONTENT_TYPE,
+                    HeaderValue::from_static("text/html; charset=utf-8"),
+                )
+                .header(
+                    axum::http::header::CACHE_CONTROL,
+                    HeaderValue::from_static("no-store, max-age=0"),
+                );
+            if disallow_search_indexing {
+                builder = builder.header(
+                    axum::http::header::HeaderName::from_static("x-robots-tag"),
+                    HeaderValue::from_static("noindex"),
+                );
+            }
+            builder
+                .body(Body::from(html.data))
+                .unwrap_or_else(|_| StatusCode::INTERNAL_SERVER_ERROR.into_response())
+        }
         None => (
             StatusCode::SERVICE_UNAVAILABLE,
             format!(

--- a/crates/board/src/tests/mod.rs
+++ b/crates/board/src/tests/mod.rs
@@ -2,6 +2,7 @@ mod authz;
 mod cfg_service;
 mod chunk_temp_storage;
 mod db;
+mod robots_indexing;
 mod room_expiry;
 mod room_gc_service;
 mod room_policy;

--- a/crates/board/src/tests/robots_indexing.rs
+++ b/crates/board/src/tests/robots_indexing.rs
@@ -1,0 +1,70 @@
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+
+use crate::{robots_txt_body, serve_html_asset, spa_fallback};
+
+fn noindex_header(response: &axum::response::Response) -> Option<&str> {
+    response
+        .headers()
+        .get("x-robots-tag")
+        .and_then(|value| value.to_str().ok())
+}
+
+async fn request_at(path: &str) -> Request<Body> {
+    Request::builder()
+        .uri(path)
+        .body(Body::empty())
+        .expect("valid request")
+}
+
+#[test]
+fn robots_txt_disallows_all_crawlers_when_indexing_disallowed() {
+    assert_eq!(robots_txt_body(true), "User-agent: *\nDisallow: /\n");
+}
+
+#[test]
+fn robots_txt_explicitly_allows_crawlers_when_indexing_allowed() {
+    assert_eq!(robots_txt_body(false), "User-agent: *\nAllow: /\n");
+}
+
+#[test]
+fn security_config_disallows_search_indexing_by_default() {
+    assert!(configrs::SecurityConfig::default().disallow_search_indexing);
+}
+
+#[test]
+fn html_fallback_carries_noindex_header_when_indexing_disallowed() {
+    let response = serve_html_asset("index.html", true);
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(noindex_header(&response), Some("noindex"));
+}
+
+#[test]
+fn html_fallback_has_no_robots_header_when_indexing_allowed() {
+    let response = serve_html_asset("index.html", false);
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(noindex_header(&response), None);
+}
+
+#[tokio::test]
+async fn spa_root_fallback_marks_html_noindex_when_indexing_disallowed() {
+    let response = spa_fallback(request_at("/").await, true).await;
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(noindex_header(&response), Some("noindex"));
+}
+
+#[tokio::test]
+async fn spa_room_fallback_stays_indexable_when_indexing_allowed() {
+    let response = spa_fallback(request_at("/some-room").await, false).await;
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(noindex_header(&response), None);
+}
+
+#[tokio::test]
+async fn api_paths_never_fall_through_to_html_regardless_of_indexing_policy() {
+    for disallow in [true, false] {
+        let response = spa_fallback(request_at("/api/v1/missing").await, disallow).await;
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+        assert_eq!(noindex_header(&response), None);
+    }
+}

--- a/crates/configrs/src/configs/app.rs
+++ b/crates/configrs/src/configs/app.rs
@@ -354,6 +354,12 @@ pub struct SecurityConfig {
     #[default = "strict-origin-when-cross-origin"]
     #[merge(strategy = overwrite_not_empty_string)]
     pub referrer_policy: String,
+
+    /// 搜索引擎索引策略：开启时服务 Disallow: / 的 robots.txt 并对 HTML 响应
+    /// 附加 X-Robots-Tag: noindex（私人分享工具默认不应被搜索引擎收录）。
+    #[default(true)]
+    #[merge(strategy = overwrite)]
+    pub disallow_search_indexing: bool,
 }
 
 #[derive(Debug, Clone, SmartDefault, Merge, serde::Deserialize, serde::Serialize)]


### PR DESCRIPTION
Closes #202

## 实现

- 新增部署级开关 `middleware.security.disallow_search_indexing`（默认 **开启**，私人分享工具默认不应被搜索引擎收录），支持 YAML / 环境变量 `MIDDLEWARE_SECURITY_DISALLOW_SEARCH_INDEXING`。
- 开启时：服务 `User-agent: *\nDisallow: /\n` 的 `robots.txt`，并对所有 HTML 响应（SPA fallback 的 index/房间模板页）附加 `X-Robots-Tag: noindex`。
- 关闭时：服务显式 `Allow: /` 的 robots.txt（避免该路径落入 SPA fallback 返回 HTML），HTML 不再带 noindex 头。
- X-Robots-Tag 只加在 HTML 响应上（`serve_html_asset` 单点），不污染 API/静态资产响应。

## 测试（happy + unhappy，沉淀于 `crates/board/src/tests/robots_indexing.rs`，8 例）

- robots.txt 两种模式的内容契约。
- SecurityConfig 默认值 = 防索引开启（产品默认契约）。
- HTML fallback：开启 → 200 + `x-robots-tag: noindex`；关闭 → 200 + 无该头。
- SPA 根路径/房间路径两种模式同上。
- unhappy：`/api/*` 永不降级为 HTML、不带索引头（两种模式）。

## 门禁

- `cargo fmt --all` ✓、`cargo clippy --workspace --all-targets --all-features` 0 warning ✓、`cargo test -p elizabeth-board --lib` 109 passed ✓