### PR TITLE
feat(storage): 接入 opendal 存储运行链路，落地 S3/R2 后端

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -920,6 +920,7 @@ dependencies = [
  "argon2",
  "async-trait",
  "axum",
+ "bytes",
  "bytesize",
  "chrono",
  "clap",
@@ -3972,6 +3973,7 @@ checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
 dependencies = [
  "bytes",
  "futures-core",
+ "futures-io",
  "futures-sink",
  "futures-util",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 
 # === Async Runtime ===
 tokio = { version = "1", features = ["full"] }
-tokio-util = { version = "0.7", features = ["io", "rt"] }
+tokio-util = { version = "0.7", features = ["compat", "io", "rt"] }
 futures = "0.3"
 
 # === Web Framework ===
@@ -89,6 +89,7 @@ shadow-rs = { version = "2", features = ["no_std"] }
 merge = "0.2"
 smart-default = "0.7"
 fs4 = "1"
+bytes = "1"
 bytesize = { version = "2", features = ["serde"] }
 humantime = "2"
 humantime-serde = "1"

--- a/crates/board/Cargo.toml
+++ b/crates/board/Cargo.toml
@@ -43,6 +43,7 @@ tower_governor = { workspace = true }
 
 serde = { workspace = true }
 serde_json = { workspace = true }
+bytes = { workspace = true }
 bytesize = { workspace = true }
 
 anyhow = { workspace = true }

--- a/crates/board/src/config.rs
+++ b/crates/board/src/config.rs
@@ -153,6 +153,21 @@ impl Default for ServerConfig {
 pub struct StorageConfig {
     pub root: PathBuf,
     pub upload_reservation_ttl_seconds: i64,
+    /// S3/R2 连接配置；None = 本地文件系统后端。
+    pub s3: Option<S3StorageConfig>,
+}
+
+/// S3 兼容对象存储连接配置（backend = s3 时使用）。
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct S3StorageConfig {
+    /// 服务端点，如 "https://s3.us-east-1.amazonaws.com" 或 R2 的账户端点
+    pub endpoint: String,
+    /// 存储桶名
+    pub bucket: String,
+    pub access_key_id: String,
+    pub secret_access_key: String,
+    /// 区域；R2 通常填 "auto"
+    pub region: Option<String>,
 }
 
 impl Default for StorageConfig {
@@ -160,6 +175,7 @@ impl Default for StorageConfig {
         Self {
             root: PathBuf::from(DEFAULT_STORAGE_ROOT),
             upload_reservation_ttl_seconds: DEFAULT_UPLOAD_RESERVATION_TTL_SECONDS,
+            s3: None,
         }
     }
 }

--- a/crates/board/src/handlers/chunked_upload/complete.rs
+++ b/crates/board/src/handlers/chunked_upload/complete.rs
@@ -109,15 +109,14 @@ pub async fn complete_file_merge(
         return Err(AppError::validation(upload_file_type_violation(&file.name)));
     }
 
-    let storage_dir = storage_root.join(room_id.to_string());
-    fs::create_dir_all(&storage_dir)
+    let key = crate::storage::unique_key(app_state.storage.as_ref(), room_id, &file.name)
         .await
-        .map_err(|e| AppError::internal(format!("创建存储目录失败：{}", e)))?;
-
-    let final_storage_path = unique_storage_path(&storage_dir, &file.name)?;
-    fs::rename(&final_file_path, &final_storage_path)
+        .map_err(|e| AppError::internal(format!("生成存储路径失败：{}", e)))?;
+    let final_storage_path = app_state
+        .storage
+        .store_file(&key, &final_file_path)
         .await
-        .map_err(|e| AppError::internal(format!("移动文件失败：{}", e)))?;
+        .map_err(|e| AppError::internal(format!("存储文件失败：{}", e)))?;
 
     reservation_repository
         .consume_reservation(
@@ -293,36 +292,6 @@ fn first_manifest_file(
     file_manifest
         .first()
         .ok_or_else(|| AppError::internal("文件清单为空"))
-}
-
-fn unique_storage_path(storage_dir: &StdPath, file_name: &str) -> Result<String, AppError> {
-    let safe_file_name = sanitize_filename::sanitize(file_name);
-    let mut final_filename = safe_file_name.clone();
-    let mut counter = 1;
-    let mut final_storage_path = storage_dir.join(&final_filename);
-
-    while final_storage_path.exists() {
-        let path = StdPath::new(&safe_file_name);
-        let stem = path
-            .file_stem()
-            .and_then(|s| s.to_str())
-            .unwrap_or(&safe_file_name);
-        let extension = path.extension().and_then(|s| s.to_str()).unwrap_or("");
-
-        final_filename = if extension.is_empty() {
-            format!("{}({})", stem, counter)
-        } else {
-            format!("{}({}).{}", stem, counter, extension)
-        };
-        final_storage_path = storage_dir.join(&final_filename);
-        counter += 1;
-
-        if counter > 1000 {
-            return Err(AppError::internal("Too many files with the same name"));
-        }
-    }
-
-    Ok(final_storage_path.to_string_lossy().into_owned())
 }
 
 async fn create_content_record(

--- a/crates/board/src/handlers/content.rs
+++ b/crates/board/src/handlers/content.rs
@@ -16,4 +16,4 @@ pub use update::update_content;
 pub use url::create_url_content;
 pub use visibility::set_content_visibility;
 
-pub(crate) use shared::{HandlerResult, ensure_room_storage, room_id_or_error};
+pub(crate) use shared::{HandlerResult, room_id_or_error};

--- a/crates/board/src/handlers/content/delete.rs
+++ b/crates/board/src/handlers/content/delete.rs
@@ -77,7 +77,7 @@ pub async fn delete_contents(
         )?;
     }
 
-    let freed_size = remove_content_files(&contents).await;
+    let freed_size = remove_content_files(app_state.storage.as_ref(), &contents).await;
     let ids: Vec<i64> = contents.iter().filter_map(|content| content.id).collect();
 
     repository
@@ -116,11 +116,14 @@ fn collect_target_contents(contents: Vec<RoomContent>, target_ids: &[i64]) -> Ve
         .collect()
 }
 
-async fn remove_content_files(contents: &[RoomContent]) -> i64 {
+async fn remove_content_files(
+    storage: &dyn crate::storage::StorageBackend,
+    contents: &[RoomContent],
+) -> i64 {
     let mut freed_size = 0;
     for content in contents {
         if let Some(path) = &content.path {
-            tokio::fs::remove_file(path).await.ok();
+            storage.delete(path).await.ok();
         }
         freed_size += content.size.unwrap_or(0);
     }

--- a/crates/board/src/handlers/content/download.rs
+++ b/crates/board/src/handlers/content/download.rs
@@ -6,10 +6,9 @@ use axum::extract::{Path as AxumPath, Query, State};
 use axum::http::HeaderValue;
 use axum::http::header::{CONTENT_DISPOSITION, CONTENT_LENGTH, CONTENT_TYPE};
 use axum::response::Response;
+use futures::StreamExt;
 use jsonwebtoken::{Algorithm, DecodingKey, Validation, decode};
 use serde::Deserialize;
-use tokio::fs;
-use tokio_util::io::ReaderStream;
 
 use crate::authz::{Authz, Resource};
 use crate::errors::AppError;
@@ -119,26 +118,32 @@ pub async fn download_content_global(
         }
     }
 
-    serve_content_stream(content).await
+    serve_content_stream(&app_state, content).await
 }
 
-async fn serve_content_stream(content: RoomContent) -> Result<Response, AppError> {
-    let path = content
+async fn serve_content_stream(
+    app_state: &Arc<AppState>,
+    content: RoomContent,
+) -> Result<Response, AppError> {
+    let locator = content
         .path
         .ok_or_else(|| AppError::not_found("Content not stored on disk"))?;
 
-    let file = fs::File::open(&path)
-        .await
-        .map_err(|_| AppError::not_found("File missing on disk"))?;
-
     let file_name = content.file_name.clone().unwrap_or_else(|| {
-        Path::new(&path)
-            .file_name()
-            .map(|s| s.to_string_lossy().to_string())
-            .unwrap_or_else(|| "download.bin".to_string())
+        locator
+            .rsplit(['/', '\\'])
+            .next()
+            .unwrap_or("download.bin")
+            .to_string()
     });
 
-    let stream = ReaderStream::new(file);
+    let stream = app_state.storage.read(&locator).await.map_err(|error| {
+        if matches!(error, crate::storage::StorageError::NotFound(_)) {
+            AppError::not_found("File missing on disk")
+        } else {
+            AppError::internal(format!("Read content failed: {error}"))
+        }
+    })?;
     let body = Body::from_stream(stream);
     let mut response = Response::new(body);
     let disposition = HeaderValue::from_str(&format!("attachment; filename=\"{file_name}\""))

--- a/crates/board/src/handlers/content/put.rs
+++ b/crates/board/src/handlers/content/put.rs
@@ -27,9 +27,8 @@ use crate::validation::RoomNameValidator;
 
 use super::upload::{
     TempUpload, consume_upload_reservation, map_reservation_error, persist_staged_uploads,
-    unique_upload_path,
 };
-use super::{HandlerResult, ensure_room_storage, room_id_or_error};
+use super::{HandlerResult, room_id_or_error};
 
 /// 单命令整文件上传：`curl -T file "$BASE/api/v1/rooms/{name}/files/{filename}"`。
 /// 内部复用预留上传流程：按 Content-Length 预留 → 流式落盘 → 校验实际大小 → 持久化并核销。
@@ -109,10 +108,13 @@ pub async fn put_content(
         .id
         .ok_or_else(|| AppError::internal("Reservation id missing"))?;
 
-    let storage_dir = ensure_room_storage(app_state.storage_root().as_ref(), room_id)
+    // 暂存到预留目录：失败路径由预留清理任务兜底，成功后经后端原子转正。
+    let scratch_dir =
+        crate::chunk_temp_storage::reservation_dir(app_state.storage_root(), reservation_id);
+    tokio::fs::create_dir_all(&scratch_dir)
         .await
         .map_err(|e| AppError::internal(format!("Failed to prepare storage directory: {e}")))?;
-    let file_path = unique_upload_path(&storage_dir, &filename)?;
+    let file_path = scratch_dir.join(format!("stage_{}", uuid::Uuid::new_v4()));
 
     let size = match write_body_to_file(body, &file_path).await {
         Ok(size) => size,

--- a/crates/board/src/handlers/content/shared.rs
+++ b/crates/board/src/handlers/content/shared.rs
@@ -1,22 +1,9 @@
-use std::path::{Path, PathBuf};
-
 use axum::Json;
-use tokio::fs;
 
 use crate::errors::AppError;
 use crate::services::RoomTokenClaims;
 
 pub(crate) type HandlerResult<T> = Result<Json<T>, AppError>;
-
-/// 确保房间存储目录存在，使用 room_id 作为目录名
-pub(crate) async fn ensure_room_storage(
-    base_dir: &Path,
-    room_id: i64,
-) -> Result<PathBuf, std::io::Error> {
-    let dir = base_dir.join(room_id.to_string());
-    fs::create_dir_all(&dir).await?;
-    Ok(dir)
-}
 
 pub(crate) fn room_id_or_error(claims: &RoomTokenClaims) -> Result<i64, AppError> {
     if claims.room_id <= 0 {

--- a/crates/board/src/handlers/content/upload.rs
+++ b/crates/board/src/handlers/content/upload.rs
@@ -23,9 +23,10 @@ use crate::repository::{
     RoomUploadReservationRepository,
 };
 use crate::state::AppState;
+use crate::storage::unique_key;
 use crate::validation::RoomNameValidator;
 
-use super::{HandlerResult, ensure_room_storage, room_id_or_error};
+use super::{HandlerResult, room_id_or_error};
 use crate::authz::{Authz, Resource};
 use crate::handlers::{AuthToken, verify_room_token};
 use crate::models::room::role::Capability;
@@ -275,11 +276,13 @@ pub async fn upload_contents(
 
     let expected_map = build_expected_manifest(expected_files)?;
 
-    let storage_dir = ensure_room_storage(app_state.storage_root().as_ref(), room_id)
+    let scratch_dir =
+        crate::chunk_temp_storage::reservation_dir(app_state.storage_root(), query.reservation_id);
+    tokio::fs::create_dir_all(&scratch_dir)
         .await
         .map_err(|e| AppError::internal(format!("Failed to prepare storage directory: {e}")))?;
 
-    let staged = stage_multipart_uploads(multipart, &expected_map, &storage_dir).await?;
+    let staged = stage_multipart_uploads(multipart, &expected_map, &scratch_dir).await?;
 
     let repository = RoomContentRepository::new(app_state.db_pool.clone());
     let (uploaded, actual_total) = persist_staged_uploads(
@@ -378,7 +381,7 @@ async fn stage_upload_field(
         )));
     }
 
-    let file_path = unique_upload_path(storage_dir, &file_name)?;
+    let file_path = storage_dir.join(format!("stage_{}", uuid::Uuid::new_v4()));
     let size = write_field_to_file(&mut field, &file_path).await?;
 
     if size != expected.size {
@@ -388,7 +391,8 @@ async fn stage_upload_field(
         )));
     }
 
-    let mime = mime_guess::from_path(&file_path)
+    // mime 按原始文件名推断；暂存文件名是随机的，不含扩展名信息。
+    let mime = mime_guess::from_path(&file_name)
         .first_raw()
         .map(|m| m.to_string());
 
@@ -400,38 +404,10 @@ async fn stage_upload_field(
     })
 }
 
-pub(super) fn unique_upload_path(storage_dir: &Path, file_name: &str) -> Result<PathBuf, AppError> {
-    let safe_file_name = sanitize_filename::sanitize(file_name);
-    let mut final_filename = safe_file_name.clone();
-    let mut counter = 1;
-    let mut file_path = storage_dir.join(&final_filename);
-
-    while file_path.exists() {
-        let path = Path::new(&safe_file_name);
-        let stem = path
-            .file_stem()
-            .and_then(|s| s.to_str())
-            .unwrap_or(&safe_file_name);
-        let extension = path.extension().and_then(|s| s.to_str()).unwrap_or("");
-
-        final_filename = if extension.is_empty() {
-            format!("{}({})", stem, counter)
-        } else {
-            format!("{}({}).{}", stem, counter, extension)
-        };
-
-        file_path = storage_dir.join(&final_filename);
-        counter += 1;
-
-        if counter > 1000 {
-            return Err(AppError::internal("Too many files with the same name"));
-        }
-    }
-
-    Ok(file_path)
-}
-
-async fn write_field_to_file(field: &mut Field<'_>, file_path: &Path) -> Result<i64, AppError> {
+pub(super) async fn write_field_to_file(
+    field: &mut Field<'_>,
+    file_path: &Path,
+) -> Result<i64, AppError> {
     let mut temp_file = fs::File::create(file_path)
         .await
         .map_err(|e| AppError::internal(format!("Cannot create file: {e}")))?;
@@ -466,8 +442,25 @@ pub(super) async fn persist_staged_uploads(
     let mut actual_total: i64 = 0;
 
     for temp in staged {
+        let key = match unique_key(app_state.storage.as_ref(), room_id, &temp.original_name).await {
+            Ok(key) => key,
+            Err(e) => {
+                cleanup_staged_uploads(staged).await;
+                return Err(AppError::internal(format!(
+                    "Resolve storage key failed: {e}"
+                )));
+            }
+        };
+        let locator = match app_state.storage.store_file(&key, &temp.path).await {
+            Ok(locator) => locator,
+            Err(e) => {
+                cleanup_staged_uploads(staged).await;
+                return Err(AppError::internal(format!("Store content failed: {e}")));
+            }
+        };
+
         let saved = match repository
-            .create(&build_file_content(room_id, owner_jti, temp))
+            .create(&build_file_content(room_id, owner_jti, temp, locator))
             .await
         {
             Ok(value) => value,
@@ -487,7 +480,12 @@ pub(super) async fn persist_staged_uploads(
     Ok((uploaded, actual_total))
 }
 
-fn build_file_content(room_id: i64, owner_jti: &str, temp: &TempUpload) -> RoomContent {
+fn build_file_content(
+    room_id: i64,
+    owner_jti: &str,
+    temp: &TempUpload,
+    locator: String,
+) -> RoomContent {
     let now = chrono::Utc::now().naive_utc();
     let mut content = RoomContent {
         id: None,
@@ -506,7 +504,7 @@ fn build_file_content(room_id: i64, owner_jti: &str, temp: &TempUpload) -> RoomC
         updated_at: now,
     };
     content.set_path(
-        temp.path.to_string_lossy().to_string(),
+        locator,
         ContentType::File,
         temp.size,
         temp.mime

--- a/crates/board/src/init/cfg_service/env_overrides.rs
+++ b/crates/board/src/init/cfg_service/env_overrides.rs
@@ -16,6 +16,7 @@ pub(super) fn apply_program_env_overrides(cfg: &mut configrs::Config) {
     apply_jwt_env_overrides(cfg);
     apply_room_env_overrides(cfg);
     apply_gc_env_overrides(cfg);
+    apply_storage_env_overrides(cfg);
     apply_middleware_env_overrides(cfg);
 }
 
@@ -111,6 +112,33 @@ fn apply_room_env_overrides(cfg: &mut configrs::Config) {
 fn apply_gc_env_overrides(cfg: &mut configrs::Config) {
     apply_env!(env_u64, "GC_INTERVAL_SECONDS", cfg.app.gc.interval_seconds);
     apply_env!(env_u32, "GC_BATCH_LIMIT", cfg.app.gc.batch_limit);
+}
+
+fn apply_storage_env_overrides(cfg: &mut configrs::Config) {
+    if let Some(backend) = env_string("STORAGE_BACKEND") {
+        cfg.app.storage.backend = match backend.trim().to_lowercase().as_str() {
+            "s3" => configrs::StorageBackendKind::S3,
+            _ => configrs::StorageBackendKind::Fs,
+        };
+    }
+    if cfg.app.storage.backend == configrs::StorageBackendKind::S3 {
+        let s3 = cfg
+            .app
+            .storage
+            .s3
+            .get_or_insert_with(configrs::S3StorageConfig::default);
+        apply_env!(env_string, "STORAGE_S3_ENDPOINT", s3.endpoint);
+        apply_env!(env_string, "STORAGE_S3_BUCKET", s3.bucket);
+        apply_env!(env_string, "STORAGE_S3_ACCESS_KEY_ID", s3.access_key_id);
+        apply_env!(
+            env_string,
+            "STORAGE_S3_SECRET_ACCESS_KEY",
+            s3.secret_access_key
+        );
+        if let Some(region) = env_string("STORAGE_S3_REGION") {
+            s3.region = Some(region);
+        }
+    }
 }
 
 fn apply_middleware_env_overrides(cfg: &mut configrs::Config) {

--- a/crates/board/src/lib.rs
+++ b/crates/board/src/lib.rs
@@ -123,6 +123,22 @@ async fn start_server(cfg: &Config) -> anyhow::Result<()> {
             } else {
                 cfg.app.upload.reservation_ttl_seconds
             },
+            s3: match cfg.app.storage.backend {
+                configrs::StorageBackendKind::S3 => {
+                    cfg.app
+                        .storage
+                        .s3
+                        .clone()
+                        .map(|s3| crate::config::S3StorageConfig {
+                            endpoint: s3.endpoint,
+                            bucket: s3.bucket,
+                            access_key_id: s3.access_key_id,
+                            secret_access_key: s3.secret_access_key,
+                            region: s3.region,
+                        })
+                }
+                configrs::StorageBackendKind::Fs => None,
+            },
         },
         room: RoomConfig::try_from(&cfg.app.room)?,
         auth: AuthConfig::new(cfg.app.jwt.secret.clone())

--- a/crates/board/src/services/mod.rs
+++ b/crates/board/src/services/mod.rs
@@ -43,7 +43,11 @@ pub struct Services {
 
 impl Services {
     /// 创建新的服务容器
-    pub fn new(config: &AppConfig, db_pool: Arc<DbPool>) -> Result<Self> {
+    pub fn new(
+        config: &AppConfig,
+        db_pool: Arc<DbPool>,
+        storage: Arc<dyn crate::storage::StorageBackend>,
+    ) -> Result<Self> {
         // 创建令牌服务
         let token_service = Arc::new(RoomTokenService::with_config(
             Arc::new(config.auth.jwt_secret.clone()),
@@ -85,7 +89,7 @@ impl Services {
         ));
         let room_lifecycle = Arc::new(RoomLifecycleService::new(
             room_lifecycle_repository,
-            config.storage.root.clone(),
+            storage,
         ));
         let room_password = Arc::new(RoomPasswordService);
         let access_code_limiter = Arc::new(AccessCodeLimiter::new());
@@ -135,7 +139,8 @@ mod tests {
         config.auth = AuthConfig::new("test-secret-key-for-unit-testing-123".to_string())?;
 
         // 创建服务
-        let services = Services::new(&config, db_pool)?;
+        let storage = crate::storage::from_config(&config.storage)?;
+        let services = Services::new(&config, db_pool, storage)?;
 
         // 验证服务创建成功
         assert!(!services.token_service.get_secret().is_empty());

--- a/crates/board/src/services/room_lifecycle.rs
+++ b/crates/board/src/services/room_lifecycle.rs
@@ -38,14 +38,17 @@ pub struct FullRoomGcStatus {
 #[derive(Clone)]
 pub struct RoomLifecycleService {
     repository: Arc<RoomLifecycleRepository>,
-    storage_root: PathBuf,
+    storage: Arc<dyn crate::storage::StorageBackend>,
 }
 
 impl RoomLifecycleService {
-    pub fn new(repository: Arc<RoomLifecycleRepository>, storage_root: PathBuf) -> Self {
+    pub fn new(
+        repository: Arc<RoomLifecycleRepository>,
+        storage: Arc<dyn crate::storage::StorageBackend>,
+    ) -> Self {
         Self {
             repository,
-            storage_root,
+            storage,
         }
     }
 
@@ -174,29 +177,13 @@ impl RoomLifecycleService {
     }
 
     async fn purge_room(&self, room_id: i64) -> Result<bool> {
-        for path in self.repository.list_content_paths(room_id).await? {
-            remove_file_if_present(Path::new(&path)).await?;
-        }
-        remove_dir_if_present(&self.storage_root.join(room_id.to_string())).await?;
+        self.storage
+            .purge_room(room_id)
+            .await
+            .with_context(|| format!("failed to purge storage for room {room_id}"))?;
         self.repository
             .delete_room_graph(room_id)
             .await
             .context("failed to delete room persistence graph")
-    }
-}
-
-async fn remove_file_if_present(path: &Path) -> Result<()> {
-    match tokio::fs::remove_file(path).await {
-        Ok(()) => Ok(()),
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
-        Err(error) => Err(error).with_context(|| format!("failed to remove {}", path.display())),
-    }
-}
-
-async fn remove_dir_if_present(path: &Path) -> Result<()> {
-    match tokio::fs::remove_dir_all(path).await {
-        Ok(()) => Ok(()),
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
-        Err(error) => Err(error).with_context(|| format!("failed to remove {}", path.display())),
     }
 }

--- a/crates/board/src/state.rs
+++ b/crates/board/src/state.rs
@@ -8,6 +8,7 @@ use anyhow::Result;
 use crate::config::AppConfig;
 use crate::db::DbPool;
 use crate::services::Services;
+use crate::storage::{StorageBackend, from_config};
 use crate::websocket::{broadcaster::Broadcaster, connection::ConnectionManager};
 
 /// 应用程序状态
@@ -21,6 +22,8 @@ pub struct AppState {
     pub config: AppConfig,
     /// 服务容器
     pub services: Services,
+    /// 内容存储后端
+    pub storage: Arc<dyn StorageBackend>,
     /// WebSocket 连接管理器
     pub connection_manager: Arc<ConnectionManager>,
     /// WebSocket 广播器
@@ -35,8 +38,22 @@ impl AppState {
         // 验证配置
         config.validate()?;
 
+        // 按配置选择内容存储后端
+        let storage = from_config(&config.storage)?;
+
+        Self::with_storage(config, db_pool, storage)
+    }
+
+    /// 用显式指定的存储后端创建应用状态（测试注入用）。
+    pub fn with_storage(
+        config: AppConfig,
+        db_pool: Arc<DbPool>,
+        storage: Arc<dyn StorageBackend>,
+    ) -> Result<Self> {
+        config.validate()?;
+
         // 创建服务
-        let services = Services::new(&config, db_pool.clone())?;
+        let services = Services::new(&config, db_pool.clone(), storage.clone())?;
 
         // 创建 WebSocket 连接管理器
         let connection_manager = Arc::new(ConnectionManager::new());
@@ -49,6 +66,7 @@ impl AppState {
             db_pool,
             config,
             services,
+            storage,
             connection_manager,
             broadcaster,
             roles_cache,

--- a/crates/board/src/storage/backend.rs
+++ b/crates/board/src/storage/backend.rs
@@ -1,274 +1,306 @@
-//! Storage backend abstraction
+//! 内容存储后端抽象
 //!
-//! This module defines a unified storage interface that supports multiple storage backends:
-//! - Local filesystem (FS)
-//! - S3-compatible object storage (AWS S3, MinIO, Cloudflare R2)
+//! `room_contents.path` 保存的是不透明的 locator 字符串，解释权在所选后端：
+//! - 本地文件系统：绝对路径（与历史行为一致，存量数据无需迁移）；
+//! - S3 兼容对象存储：对象 key（如 "5/report.pdf"）。
 //!
-//! # Architecture
-//!
-//! The storage layer is designed with the following principles:
-//! - **Abstraction**: Single `StorageBackend` trait for all storage operations
-//! - **Flexibility**: Easy to add new storage backends
-//! - **Type Safety**: Rust's type system ensures correct usage
-//! - **Async-first**: All operations are async for better performance
+//! 上传侧统一先把请求体落到本地暂存区（预留目录），再由后端把暂存文件
+//! 转为正式内容（FS 用 rename 原子落位，S3 流式上传），保证失败路径
+//! 不会在正式存储里留下半截内容。
+
+use std::path::{Path, PathBuf};
+use std::pin::Pin;
 
 use async_trait::async_trait;
-use opendal::{Builder, Operator};
-use std::path::Path;
+use futures::{Stream, StreamExt};
+use tokio::io::AsyncWriteExt;
 
-/// Storage backend type enumeration
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum StorageType {
-    /// Local filesystem storage
-    Fs,
-    /// S3-compatible object storage (AWS S3, MinIO, R2)
-    S3,
-}
+use crate::config::S3StorageConfig;
 
-/// Storage backend configuration
-#[derive(Debug, Clone)]
-pub struct StorageConfig {
-    /// Storage type
-    pub storage_type: StorageType,
+pub type ContentStream = Pin<Box<dyn Stream<Item = StorageResult<bytes::Bytes>> + Send>>;
 
-    /// Root path for file storage
-    /// - For FS: local directory path
-    /// - For S3: bucket prefix/path
-    pub root: String,
-
-    /// S3-specific configuration (only used when storage_type is S3)
-    pub s3_config: Option<S3Config>,
-}
-
-/// S3-compatible storage configuration
-#[derive(Debug, Clone)]
-pub struct S3Config {
-    /// S3 endpoint URL (e.g., "https://s3.amazonaws.com")
-    pub endpoint: String,
-
-    /// Bucket name
-    pub bucket: String,
-
-    /// AWS access key ID
-    pub access_key_id: String,
-
-    /// AWS secret access key
-    pub secret_access_key: String,
-
-    /// AWS region (e.g., "us-east-1")
-    pub region: Option<String>,
-}
-
-/// Result type for storage operations
-pub type StorageResult<T> = Result<T, StorageError>;
-
-/// Storage error types
+/// 存储操作错误
 #[derive(Debug, thiserror::Error)]
 pub enum StorageError {
-    /// I/O error occurred
+    /// I/O 错误
     #[error("I/O error: {0}")]
     Io(#[from] std::io::Error),
 
-    /// Opendal error occurred
+    /// Opendal 错误
     #[error("Storage error: {0}")]
     Opendal(#[from] opendal::Error),
 
-    /// File not found
-    #[error("File not found: {0}")]
+    /// 内容不存在
+    #[error("Content not found: {0}")]
     NotFound(String),
 
-    /// Permission denied
-    #[error("Permission denied: {0}")]
-    PermissionDenied(String),
-
-    /// Invalid path
-    #[error("Invalid path: {0}")]
-    InvalidPath(String),
-
-    /// Other error
+    /// 其他错误
     #[error("Storage error: {0}")]
     Other(String),
 }
 
-/// Storage backend trait
+pub type StorageResult<T> = Result<T, StorageError>;
+
+/// 内容存储后端
 ///
-/// This trait defines the interface for all storage backends.
-/// All operations are async and return `StorageResult`.
+/// key 形如 "{room_id}/{file_name}"（已做文件名净化与冲突唯一化）；
+/// locator 是持久化到 `room_contents.path` 的内容寻址串，由后端解释。
 #[async_trait]
 pub trait StorageBackend: Send + Sync {
-    /// Get a file from storage
-    ///
-    /// # Arguments
-    /// * `path` - Relative path to the file
-    ///
-    /// # Returns
-    /// File contents as bytes
-    async fn get(&self, path: &str) -> StorageResult<Vec<u8>>;
+    /// key 对应的正式内容是否已存在（用于上传文件名冲突检测）。
+    async fn exists_key(&self, key: &str) -> StorageResult<bool>;
 
-    /// Put a file to storage
-    ///
-    /// # Arguments
-    /// * `path` - Relative path where to store the file
-    /// * `data` - File contents as bytes
-    async fn put(&self, path: &str, data: Vec<u8>) -> StorageResult<()>;
+    /// 把本地暂存文件的内容写入 key，返回应持久化的 locator。
+    async fn store_file(&self, key: &str, local: &Path) -> StorageResult<String>;
 
-    /// Delete a file from storage
-    ///
-    /// # Arguments
-    /// * `path` - Relative path to the file to delete
-    async fn delete(&self, path: &str) -> StorageResult<()>;
+    /// 打开 locator 的内容读取流。
+    async fn read(&self, locator: &str) -> StorageResult<ContentStream>;
 
-    /// List files in a directory
-    ///
-    /// # Arguments
-    /// * `path` - Relative path to the directory
-    ///
-    /// # Returns
-    /// List of file paths in the directory
-    async fn list(&self, path: &str) -> StorageResult<Vec<String>>;
+    /// 删除 locator 对应内容；不存在视为成功。
+    async fn delete(&self, locator: &str) -> StorageResult<()>;
 
-    /// Check if a file exists
-    ///
-    /// # Arguments
-    /// * `path` - Relative path to the file
-    ///
-    /// # Returns
-    /// `true` if file exists, `false` otherwise
-    async fn exists(&self, path: &str) -> StorageResult<bool>;
+    /// 清空房间全部存储内容（房间回收）。
+    async fn purge_room(&self, room_id: i64) -> StorageResult<()>;
 }
 
-/// Opendal-based storage backend implementation
-///
-/// This implementation uses Opendal as the underlying storage engine,
-/// providing support for multiple storage services through a unified API.
+/// 本地文件系统后端。locator = 绝对路径。
+pub struct FsBackend {
+    root: PathBuf,
+}
+
+impl FsBackend {
+    pub fn new(root: PathBuf) -> Self {
+        Self { root }
+    }
+
+    fn absolute(&self, key: &str) -> PathBuf {
+        self.root.join(key)
+    }
+}
+
+#[async_trait]
+impl StorageBackend for FsBackend {
+    async fn exists_key(&self, key: &str) -> StorageResult<bool> {
+        Ok(tokio::fs::try_exists(self.absolute(key)).await?)
+    }
+
+    async fn store_file(&self, key: &str, local: &Path) -> StorageResult<String> {
+        let target = self.absolute(key);
+        if let Some(parent) = target.parent() {
+            tokio::fs::create_dir_all(parent).await?;
+        }
+        // 暂存区与正式目录同在 storage root 下，rename 原子且无跨盘问题。
+        tokio::fs::rename(local, &target).await?;
+        Ok(target.to_string_lossy().into_owned())
+    }
+
+    async fn read(&self, locator: &str) -> StorageResult<ContentStream> {
+        let file = match tokio::fs::File::open(locator).await {
+            Ok(file) => file,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                return Err(StorageError::NotFound(locator.to_string()));
+            }
+            Err(error) => return Err(error.into()),
+        };
+        Ok(Box::pin(
+            tokio_util::io::ReaderStream::new(file).map(|chunk| chunk.map_err(StorageError::from)),
+        ))
+    }
+
+    async fn delete(&self, locator: &str) -> StorageResult<()> {
+        match tokio::fs::remove_file(locator).await {
+            Ok(()) => Ok(()),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(error) => Err(error.into()),
+        }
+    }
+
+    async fn purge_room(&self, room_id: i64) -> StorageResult<()> {
+        match tokio::fs::remove_dir_all(self.root.join(room_id.to_string())).await {
+            Ok(()) => Ok(()),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(error) => Err(error.into()),
+        }
+    }
+}
+
+/// Opendal 后端（S3 兼容对象存储）。locator = 对象 key。
 pub struct OpendalBackend {
-    /// Opendal operator
-    operator: Operator,
+    operator: opendal::Operator,
 }
 
 impl OpendalBackend {
-    /// Create a new Opendal backend from configuration
-    ///
-    /// # Arguments
-    /// * `config` - Storage configuration
-    ///
-    /// # Returns
-    /// A new `OpendalBackend` instance
-    pub fn new(config: StorageConfig) -> StorageResult<Self> {
-        let operator = match config.storage_type {
-            StorageType::Fs => {
-                // Build filesystem operator
-                let builder = opendal::services::Fs::default().root(&config.root);
-
-                Operator::new(builder).map_err(StorageError::from)?
-            }
-            StorageType::S3 => {
-                // Build S3 operator
-                let s3_cfg = config.s3_config.ok_or_else(|| {
-                    StorageError::Other("S3 configuration is required for S3 storage".to_string())
-                })?;
-
-                let mut builder = opendal::services::S3::default()
-                    .root(&config.root)
-                    .endpoint(&s3_cfg.endpoint)
-                    .bucket(&s3_cfg.bucket)
-                    .access_key_id(&s3_cfg.access_key_id)
-                    .secret_access_key(&s3_cfg.secret_access_key);
-
-                if let Some(region) = s3_cfg.region {
-                    builder = builder.region(&region);
-                }
-
-                Operator::new(builder).map_err(StorageError::from)?
-            }
-        };
-
-        Ok(Self { operator })
+    /// 用给定 Operator 构造（生产走 S3，测试可注入任意 opendal 服务）。
+    pub fn from_operator(operator: opendal::Operator) -> Self {
+        Self { operator }
     }
 
-    /// Get the underlying Opendal operator
-    pub fn operator(&self) -> &Operator {
-        &self.operator
+    /// 构造 S3 兼容后端（AWS S3 / MinIO / Cloudflare R2）。
+    pub fn s3(config: &S3StorageConfig, root: &str) -> StorageResult<Self> {
+        if config.endpoint.trim().is_empty() || config.bucket.trim().is_empty() {
+            return Err(StorageError::Other(
+                "storage.s3.endpoint and storage.s3.bucket are required when backend = s3"
+                    .to_string(),
+            ));
+        }
+
+        let builder = opendal::services::S3::default()
+            .root(root)
+            .endpoint(&config.endpoint)
+            .bucket(&config.bucket)
+            .access_key_id(&config.access_key_id)
+            .secret_access_key(&config.secret_access_key);
+
+        let builder = if let Some(region) = &config.region {
+            builder.region(region)
+        } else {
+            builder
+        };
+
+        Ok(Self {
+            operator: opendal::Operator::new(builder)?,
+        })
     }
 }
 
 #[async_trait]
 impl StorageBackend for OpendalBackend {
-    async fn get(&self, path: &str) -> StorageResult<Vec<u8>> {
-        let bytes = self
-            .operator
-            .read(path)
-            .await
-            .map_err(StorageError::from)?
-            .to_vec();
-        Ok(bytes)
+    async fn exists_key(&self, key: &str) -> StorageResult<bool> {
+        Ok(self.operator.exists(key).await?)
     }
 
-    async fn put(&self, path: &str, data: Vec<u8>) -> StorageResult<()> {
+    async fn store_file(&self, key: &str, local: &Path) -> StorageResult<String> {
+        use tokio_util::compat::TokioAsyncReadCompatExt;
+
+        let file = tokio::fs::File::open(local).await?;
+        let mut writer = self.operator.writer(key).await?.into_futures_async_write();
+        futures::io::copy(&mut file.compat(), &mut writer)
+            .await
+            .map_err(StorageError::from)?;
+        futures::AsyncWriteExt::close(&mut writer)
+            .await
+            .map_err(StorageError::from)?;
+        Ok(key.to_string())
+    }
+
+    async fn read(&self, locator: &str) -> StorageResult<ContentStream> {
+        let reader = self.operator.reader(locator).await.map_err(|error| {
+            if error.kind() == opendal::ErrorKind::NotFound {
+                StorageError::NotFound(locator.to_string())
+            } else {
+                StorageError::Opendal(error)
+            }
+        })?;
+        let stream = reader.into_bytes_stream(..).await?;
+        Ok(Box::pin(
+            stream.map(|chunk| chunk.map_err(StorageError::from)),
+        ))
+    }
+
+    async fn delete(&self, locator: &str) -> StorageResult<()> {
+        self.operator.delete(locator).await?;
+        Ok(())
+    }
+
+    async fn purge_room(&self, room_id: i64) -> StorageResult<()> {
         self.operator
-            .write(path, data)
-            .await
-            .map(|_| ())
-            .map_err(StorageError::from)
-    }
-
-    async fn delete(&self, path: &str) -> StorageResult<()> {
-        self.operator.delete(path).await.map_err(StorageError::from)
-    }
-
-    async fn list(&self, path: &str) -> StorageResult<Vec<String>> {
-        let entries = self.operator.list(path).await.map_err(StorageError::from)?;
-
-        let files = entries
-            .into_iter()
-            .map(|entry| entry.path().to_string())
-            .collect();
-
-        Ok(files)
-    }
-
-    async fn exists(&self, path: &str) -> StorageResult<bool> {
-        self.operator.exists(path).await.map_err(StorageError::from)
+            .delete_with(&format!("{room_id}/"))
+            .recursive(true)
+            .await?;
+        Ok(())
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use tempfile::TempDir;
-
-    #[tokio::test]
-    async fn test_fs_storage() {
-        let temp_dir = TempDir::new().unwrap();
-        let root = temp_dir.path().to_str().unwrap().to_string();
-
-        let config = StorageConfig {
-            storage_type: StorageType::Fs,
-            root,
-            s3_config: None,
-        };
-
-        let backend = OpendalBackend::new(config).unwrap();
-
-        // Test put
-        backend
-            .put("test.txt", b"Hello, World!".to_vec())
-            .await
-            .unwrap();
-
-        // Test exists
-        assert!(backend.exists("test.txt").await.unwrap());
-
-        // Test get
-        let data = backend.get("test.txt").await.unwrap();
-        assert_eq!(data, b"Hello, World!");
-
-        // Test list
-        let files = backend.list("").await.unwrap();
-        assert!(files.contains(&"test.txt".to_string()));
-
-        // Test delete
-        backend.delete("test.txt").await.unwrap();
-        assert!(!backend.exists("test.txt").await.unwrap());
+/// 按部署配置选择存储后端。
+///
+/// 切换到对象存储后，新内容写入主后端；历史本地内容（locator 以 `/` 开头）
+/// 仍由本机 FS 后端解释，保持可读可删，无需迁移即可继续下载。
+pub fn from_config(
+    config: &crate::config::StorageConfig,
+) -> StorageResult<std::sync::Arc<dyn StorageBackend>> {
+    match &config.s3 {
+        Some(s3) => Ok(std::sync::Arc::new(RouterBackend::new(
+            OpendalBackend::s3(s3, "/")?,
+            FsBackend::new(config.root.clone()),
+        ))),
+        None => Ok(std::sync::Arc::new(FsBackend::new(config.root.clone()))),
     }
+}
+
+/// 双后端路由：locator 以 `/` 开头 = 历史 FS 绝对路径；其余 = 主后端的 key。
+pub struct RouterBackend {
+    primary: OpendalBackend,
+    local_fs: FsBackend,
+}
+
+impl RouterBackend {
+    pub fn new(primary: OpendalBackend, local_fs: FsBackend) -> Self {
+        Self { primary, local_fs }
+    }
+}
+
+#[async_trait]
+impl StorageBackend for RouterBackend {
+    async fn exists_key(&self, key: &str) -> StorageResult<bool> {
+        self.primary.exists_key(key).await
+    }
+
+    async fn store_file(&self, key: &str, local: &Path) -> StorageResult<String> {
+        self.primary.store_file(key, local).await
+    }
+
+    async fn read(&self, locator: &str) -> StorageResult<ContentStream> {
+        if locator.starts_with('/') {
+            self.local_fs.read(locator).await
+        } else {
+            self.primary.read(locator).await
+        }
+    }
+
+    async fn delete(&self, locator: &str) -> StorageResult<()> {
+        if locator.starts_with('/') {
+            self.local_fs.delete(locator).await
+        } else {
+            self.primary.delete(locator).await
+        }
+    }
+
+    async fn purge_room(&self, room_id: i64) -> StorageResult<()> {
+        self.primary.purge_room(room_id).await
+    }
+}
+
+/// 计算唯一 key：冲突时追加 (N)。文件名统一净化，杜绝路径逃逸。
+pub async fn unique_key(
+    backend: &dyn StorageBackend,
+    room_id: i64,
+    file_name: &str,
+) -> StorageResult<String> {
+    let safe_name = sanitize_filename::sanitize(file_name);
+    let base_key = format!("{room_id}/{safe_name}");
+    if !backend.exists_key(&base_key).await? {
+        return Ok(base_key);
+    }
+
+    let path = Path::new(&safe_name);
+    let stem = path
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or(&safe_name);
+    let extension = path.extension().and_then(|s| s.to_str()).unwrap_or("");
+
+    for counter in 1..1000 {
+        let candidate = if extension.is_empty() {
+            format!("{room_id}/{stem}({counter})")
+        } else {
+            format!("{room_id}/{stem}({counter}).{extension}")
+        };
+        if !backend.exists_key(&candidate).await? {
+            return Ok(candidate);
+        }
+    }
+
+    Err(StorageError::Other(
+        "Too many files with the same name".to_string(),
+    ))
 }

--- a/crates/board/src/storage/mod.rs
+++ b/crates/board/src/storage/mod.rs
@@ -1,30 +1,13 @@
-//! Storage abstraction layer
+//! 内容存储抽象层
 //!
-//! This module provides a unified storage interface that supports multiple storage backends:
-//! - Local filesystem (FS)
-//! - S3-compatible object storage (AWS S3, MinIO, Cloudflare R2)
-//!
-//! # Example
-//!
-//! ```rust,no_run
-//! use board::storage::{OpendalBackend, StorageBackend, StorageConfig, StorageType};
-//!
-//! # async fn example() -> board::storage::StorageResult<()> {
-//! let config = StorageConfig {
-//!     storage_type: StorageType::Fs,
-//!     root: "/tmp/storage".to_string(),
-//!     s3_config: None,
-//! };
-//!
-//! let backend = OpendalBackend::new(config)?;
-//! backend.put("test.txt", b"Hello".to_vec()).await?;
-//! # Ok(())
-//! # }
-//! ```
+//! 统一本地文件系统与 S3 兼容对象存储（AWS S3 / MinIO / Cloudflare R2）。
+//! `room_contents.path` 保存后端解释的不透明 locator：以 `/` 开头的是历史
+//! FS 绝对路径（永远由本地后端解释，保证存量可读），其余是当前主后端的
+//! 对象 key。上传先落本地暂存区，再经后端原子转正。
 
 pub mod backend;
 
 pub use backend::{
-    OpendalBackend, S3Config, StorageBackend, StorageConfig, StorageError, StorageResult,
-    StorageType,
+    ContentStream, FsBackend, OpendalBackend, RouterBackend, StorageBackend, StorageError,
+    StorageResult, from_config, unique_key,
 };

--- a/crates/board/src/tests/mod.rs
+++ b/crates/board/src/tests/mod.rs
@@ -9,4 +9,5 @@ mod room_policy;
 mod rooms_issue_token;
 mod scheduler;
 mod secret_redaction;
+mod storage_backend;
 mod upload_file_policy;

--- a/crates/board/src/tests/storage_backend.rs
+++ b/crates/board/src/tests/storage_backend.rs
@@ -1,0 +1,191 @@
+use tempfile::TempDir;
+
+use crate::config::S3StorageConfig;
+use crate::storage::{
+    FsBackend, OpendalBackend, RouterBackend, StorageBackend, from_config, unique_key,
+};
+
+async fn write_local(path: &std::path::Path, contents: &[u8]) {
+    if let Some(parent) = path.parent() {
+        tokio::fs::create_dir_all(parent).await.unwrap();
+    }
+    tokio::fs::write(path, contents).await.unwrap();
+}
+
+fn assert_locator_keys(locator: &str) {
+    // Opendal 后端的 locator 是对象 key，不允许绝对路径。
+    assert!(
+        !locator.starts_with('/'),
+        "locator must be a key: {locator}"
+    );
+}
+
+#[tokio::test]
+async fn fs_backend_stores_reads_and_purges() {
+    let root = TempDir::new().unwrap();
+    let backend = FsBackend::new(root.path().to_path_buf());
+
+    let local = root.path().join("staging.bin");
+    write_local(&local, b"payload").await;
+
+    let locator = backend.store_file("7/data.bin", &local).await.unwrap();
+    assert!(locator.starts_with(root.path().to_str().unwrap()));
+    assert!(!local.exists(), "FS 后端用 rename 转正，暂存文件应消失");
+    assert!(backend.exists_key("7/data.bin").await.unwrap());
+
+    use futures::StreamExt;
+    let stream = backend.read(&locator).await.unwrap();
+    let bytes: Vec<u8> = stream
+        .map(|chunk| chunk.unwrap())
+        .collect::<Vec<_>>()
+        .await
+        .concat();
+    assert_eq!(bytes, b"payload");
+
+    backend.delete(&locator).await.unwrap();
+    assert!(!backend.exists_key("7/data.bin").await.unwrap());
+    // 删除不存在的内容视为成功
+    backend.delete(&locator).await.unwrap();
+}
+
+#[tokio::test]
+async fn fs_backend_purge_room_removes_directory() {
+    let root = TempDir::new().unwrap();
+    let backend = FsBackend::new(root.path().to_path_buf());
+
+    let local = root.path().join("x.bin");
+    write_local(&local, b"x").await;
+    backend.store_file("3/x.bin", &local).await.unwrap();
+
+    backend.purge_room(3).await.unwrap();
+    assert!(!root.path().join("3").exists());
+    // 房间不存在时 purge 也应成功
+    backend.purge_room(999).await.unwrap();
+}
+
+#[tokio::test]
+async fn opendal_backend_uses_object_keys_as_locators() {
+    let root = TempDir::new().unwrap();
+    let operator = opendal::Operator::new(
+        opendal::services::Fs::default().root(root.path().to_str().unwrap()),
+    )
+    .unwrap();
+    let backend = OpendalBackend::from_operator(operator);
+
+    let local = root.path().join("staging.txt");
+    write_local(&local, b"opendal payload").await;
+
+    let locator = backend.store_file("11/notes.txt", &local).await.unwrap();
+    assert_locator_keys(&locator);
+
+    use futures::StreamExt;
+    let stream = backend.read(&locator).await.unwrap();
+    let bytes: Vec<u8> = stream
+        .map(|chunk| chunk.unwrap())
+        .collect::<Vec<_>>()
+        .await
+        .concat();
+    assert_eq!(bytes, b"opendal payload");
+
+    backend.purge_room(11).await.unwrap();
+    assert!(!backend.exists_key("11/notes.txt").await.unwrap());
+}
+
+#[tokio::test]
+async fn unique_key_sanitizes_names_and_avoids_collisions() {
+    let root = TempDir::new().unwrap();
+    let backend = FsBackend::new(root.path().to_path_buf());
+
+    // 路径穿越形状的名字被净化为安全 key：不含分隔符、不指向父目录
+    let key = unique_key(&backend, 5, "../../etc/passwd").await.unwrap();
+    let name = key.strip_prefix("5/").unwrap();
+    assert!(!name.contains('/') && !name.contains('\\') && name != "..");
+
+    // 冲突时追加 (N)
+    let local = root.path().join("tmp.bin");
+    write_local(&local, b"1").await;
+    let first = unique_key(&backend, 5, "report.pdf").await.unwrap();
+    backend.store_file(&first, &local).await.unwrap();
+    let second = unique_key(&backend, 5, "report.pdf").await.unwrap();
+    assert_eq!(second, "5/report(1).pdf");
+}
+
+#[tokio::test]
+async fn from_config_selects_backend_by_s3_presence() {
+    let root = TempDir::new().unwrap();
+
+    let fs_config = crate::config::StorageConfig {
+        root: root.path().to_path_buf(),
+        upload_reservation_ttl_seconds: 600,
+        s3: None,
+    };
+    assert!(from_config(&fs_config).is_ok());
+
+    let s3_config = crate::config::StorageConfig {
+        s3: Some(S3StorageConfig {
+            endpoint: "https://s3.example.com".to_string(),
+            bucket: "elizabeth".to_string(),
+            access_key_id: "key".to_string(),
+            secret_access_key: "secret".to_string(), // pragma: allowlist secret
+            region: Some("auto".to_string()),
+        }),
+        ..fs_config.clone()
+    };
+    // 只验证构造成功；不触网，不发起真实 S3 请求
+    assert!(from_config(&s3_config).is_ok());
+}
+
+#[tokio::test]
+async fn from_config_rejects_incomplete_s3_settings() {
+    let root = TempDir::new().unwrap();
+    let config = crate::config::StorageConfig {
+        root: root.path().to_path_buf(),
+        upload_reservation_ttl_seconds: 600,
+        s3: Some(S3StorageConfig {
+            endpoint: String::new(),
+            bucket: String::new(),
+            access_key_id: String::new(),
+            secret_access_key: String::new(), // pragma: allowlist secret
+            region: None,
+        }),
+    };
+    assert!(from_config(&config).is_err());
+}
+
+#[tokio::test]
+async fn router_backend_serves_legacy_fs_locators_and_new_keys() {
+    let fs_root = TempDir::new().unwrap();
+    let op_root = TempDir::new().unwrap();
+    let primary = OpendalBackend::from_operator(
+        opendal::Operator::new(
+            opendal::services::Fs::default().root(op_root.path().to_str().unwrap()),
+        )
+        .unwrap(),
+    );
+    let backend = RouterBackend::new(primary, FsBackend::new(fs_root.path().to_path_buf()));
+
+    // 历史 FS locator（绝对路径）仍可读
+    let legacy_path = fs_root.path().join("9/old.bin");
+    write_local(&legacy_path, b"legacy").await;
+    use futures::StreamExt;
+    let stream = backend.read(legacy_path.to_str().unwrap()).await.unwrap();
+    let bytes: Vec<u8> = stream
+        .map(|chunk| chunk.unwrap())
+        .collect::<Vec<_>>()
+        .await
+        .concat();
+    assert_eq!(bytes, b"legacy");
+
+    // 新 key 走主后端
+    let local = op_root.path().join("staging.bin");
+    write_local(&local, b"new").await;
+    let locator = backend.store_file("9/new.bin", &local).await.unwrap();
+    assert!(!locator.starts_with('/'));
+    let stream = backend.read(&locator).await.unwrap();
+    let bytes: Vec<u8> = stream
+        .map(|chunk| chunk.unwrap())
+        .collect::<Vec<_>>()
+        .await
+        .concat();
+    assert_eq!(bytes, b"new");
+}

--- a/crates/board/tests/api_integration/direct_upload.rs
+++ b/crates/board/tests/api_integration/direct_upload.rs
@@ -88,7 +88,6 @@ async fn test_put_upload_returns_download_url_and_downloads_back() -> Result<()>
     let response = put_upload(&app, "direct-upload", "report.txt", Some(&token), payload).await?;
     assert_eq!(response.status(), StatusCode::OK);
     let json = body_json(response).await?;
-
     assert_eq!(json["current_size"], json!(payload.len() as i64));
     let uploaded = json["uploaded"].as_array().expect("uploaded array");
     assert_eq!(uploaded.len(), 1);

--- a/crates/board/tests/api_integration/mod.rs
+++ b/crates/board/tests/api_integration/mod.rs
@@ -4,4 +4,5 @@ mod direct_upload;
 mod identity_codes;
 mod message_pagination;
 mod roles;
+mod storage_backends;
 mod tokens;

--- a/crates/board/tests/api_integration/storage_backends.rs
+++ b/crates/board/tests/api_integration/storage_backends.rs
@@ -1,0 +1,144 @@
+//! 存储后端无关性（issue #197）：把 Opendal 后端（locator = 对象 key）注入
+//! AppState，验证上传 / 下载 / PUT / 删除等 HTTP 流程在非文件系统后端下行为一致。
+
+use std::sync::Arc;
+
+use anyhow::Result;
+use axum::{
+    body::Body,
+    http::{Method, Request, StatusCode},
+};
+use board::storage::OpendalBackend;
+use serde_json::{Value, json};
+use tempfile::TempDir;
+use tower::ServiceExt;
+use uuid::Uuid;
+
+use crate::common::http::{assert_status, create_request as create_http_request};
+
+async fn body_json(response: axum::response::Response) -> Result<Value> {
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX).await?;
+    Ok(serde_json::from_slice(&bytes)?)
+}
+
+#[tokio::test]
+async fn test_http_flows_work_against_opendal_backend() -> Result<()> {
+    // 内存库 + Opendal 后端（locator = 对象 key）。
+    // 独立临时目录承载 opendal Fs operator；TempDir 保持存活到测试结束。
+    let opendal_root = TempDir::new()?;
+    let operator = opendal::Operator::new(
+        opendal::services::Fs::default().root(opendal_root.path().to_str().unwrap()),
+    )?;
+    let storage: Arc<dyn board::storage::StorageBackend> =
+        Arc::new(OpendalBackend::from_operator(operator));
+    let (app, _pool) = crate::common::create_test_app_with_storage(Some(storage)).await?;
+
+    // 建房
+    let room_name = format!("opendal-room-{}", Uuid::new_v4().simple());
+    let create = create_http_request(
+        Method::POST,
+        &format!("/api/v1/rooms/{room_name}"),
+        Some(Body::from(json!({}).to_string())),
+    );
+    let response = app.clone().oneshot(create).await?;
+    assert_status(&response, StatusCode::OK);
+    let token = body_json(response).await?["token"]
+        .as_str()
+        .expect("admin token")
+        .to_string();
+
+    // multipart 上传：locator 必须是对象 key（无前导 /）
+    let boundary = "----opendal-backend-boundary";
+    let mut multipart = format!(
+        "--{boundary}\r\nContent-Disposition: form-data; name=\"file\"; filename=\"notes.txt\"\r\nContent-Type: text/plain\r\n\r\n"
+    )
+    .into_bytes();
+    multipart.extend_from_slice(b"opendal backend payload");
+    multipart.extend_from_slice(format!("\r\n--{boundary}--\r\n").as_bytes());
+
+    let prepare = create_http_request(
+        Method::POST,
+        &format!("/api/v1/rooms/{room_name}/contents/prepare?token={token}"),
+        Some(Body::from(
+            json!({"files": [{"name": "notes.txt", "size": 23, "mime": "text/plain"}]}).to_string(),
+        )),
+    );
+    let response = app.clone().oneshot(prepare).await?;
+    assert_status(&response, StatusCode::OK);
+    let reservation_id = body_json(response).await?["reservation_id"]
+        .as_i64()
+        .expect("reservation id");
+
+    let upload = Request::builder()
+        .method(Method::POST)
+        .uri(format!(
+            "/api/v1/rooms/{room_name}/contents?token={token}&reservation_id={reservation_id}"
+        ))
+        .header(
+            "content-type",
+            format!("multipart/form-data; boundary={boundary}"),
+        )
+        .body(Body::from(multipart))?;
+    let response = app.clone().oneshot(upload).await?;
+    assert_status(&response, StatusCode::OK);
+    let uploaded = body_json(response).await?;
+    let content_id = uploaded["uploaded"][0]["id"].as_i64().expect("content id");
+
+    // 下载回读
+    let download = create_http_request(
+        Method::GET,
+        &format!("/api/v1/contents/{content_id}?token={token}"),
+        None,
+    );
+    let response = app.clone().oneshot(download).await?;
+    assert_status(&response, StatusCode::OK);
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX).await?;
+    assert_eq!(&bytes[..], b"opendal backend payload");
+
+    // PUT 单命令上传 + 回读
+    let put = Request::builder()
+        .method(Method::PUT)
+        .uri(format!("/api/v1/rooms/{room_name}/files/report.md"))
+        .header("content-length", "5")
+        .header("authorization", format!("Bearer {token}"))
+        .body(Body::from("# ok\n".to_string()))?;
+    let response = app.clone().oneshot(put).await?;
+    assert_status(&response, StatusCode::OK);
+    let put_json = body_json(response).await?;
+    let report_id = put_json["uploaded"][0]["id"]
+        .as_i64()
+        .expect("put content id");
+    assert!(
+        put_json["uploaded"][0]["download_url"]
+            .as_str()
+            .unwrap()
+            .ends_with(&format!("/contents/{report_id}"))
+    );
+
+    let download = create_http_request(
+        Method::GET,
+        &format!("/api/v1/contents/{report_id}?token={token}"),
+        None,
+    );
+    let response = app.clone().oneshot(download).await?;
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX).await?;
+    assert_eq!(&bytes[..], b"# ok\n");
+
+    // 删除：Opendal delete 不应报错，且删除后下载 404
+    let delete = create_http_request(
+        Method::DELETE,
+        &format!("/api/v1/rooms/{room_name}/contents?token={token}"),
+        Some(Body::from(json!({"ids": [content_id]}).to_string())),
+    );
+    let response = app.clone().oneshot(delete).await?;
+    assert_status(&response, StatusCode::OK);
+    let download = create_http_request(
+        Method::GET,
+        &format!("/api/v1/contents/{content_id}?token={token}"),
+        None,
+    );
+    let response = app.clone().oneshot(download).await?;
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+
+    Ok(())
+}

--- a/crates/board/tests/common/mod.rs
+++ b/crates/board/tests/common/mod.rs
@@ -22,6 +22,13 @@ const TEST_DB_URL: &str = "sqlite::memory:";
 
 /// 创建测试应用
 pub async fn create_test_app() -> Result<(axum::Router, Arc<board::db::DbPool>)> {
+    create_test_app_with_storage(None).await
+}
+
+/// 创建测试应用；提供 storage 时以显式后端替换配置推导出的默认后端。
+pub async fn create_test_app_with_storage(
+    storage: Option<Arc<dyn board::storage::StorageBackend>>,
+) -> Result<(axum::Router, Arc<board::db::DbPool>)> {
     // 创建测试数据库
     let db_pool = Arc::new(
         DbPoolSettings::new(TEST_DB_URL)
@@ -69,6 +76,7 @@ pub async fn create_test_app() -> Result<(axum::Router, Arc<board::db::DbPool>)>
         storage: StorageConfig {
             root: std::env::temp_dir().join(format!("elizabeth-test-{}", Uuid::new_v4())),
             upload_reservation_ttl_seconds: DEFAULT_UPLOAD_RESERVATION_TTL_SECONDS,
+            s3: None,
         },
         room: RoomConfig {
             defaults: board::config::RoomCreationDefaults {
@@ -84,7 +92,10 @@ pub async fn create_test_app() -> Result<(axum::Router, Arc<board::db::DbPool>)>
     };
 
     // 创建应用状态
-    let app_state = Arc::new(AppState::new(app_config, db_pool.clone())?);
+    let app_state = Arc::new(match storage {
+        Some(storage) => AppState::with_storage(app_config, db_pool.clone(), storage)?,
+        None => AppState::new(app_config, db_pool.clone())?,
+    });
 
     // 创建路由
     let (status_router, mut api) = board::route::status::api_router().split_for_parts();

--- a/crates/configrs/src/configs/app.rs
+++ b/crates/configrs/src/configs/app.rs
@@ -111,12 +111,67 @@ impl fmt::Debug for JwtConfig {
     }
 }
 
+/// 内容存储后端类型。
+#[derive(Debug, Clone, Copy, PartialEq, Eq, SmartDefault, serde::Deserialize, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum StorageBackendKind {
+    /// 本地文件系统（默认）
+    #[default]
+    Fs,
+    /// S3 兼容对象存储（AWS S3 / MinIO / Cloudflare R2）
+    S3,
+}
+
+/// S3 兼容对象存储连接配置。
+#[derive(Merge, Clone, SmartDefault, serde::Deserialize, serde::Serialize)]
+#[serde(default)]
+pub struct S3StorageConfig {
+    #[default(String::new())]
+    #[merge(strategy = overwrite_not_empty_string)]
+    pub endpoint: String,
+    #[default(String::new())]
+    #[merge(strategy = overwrite_not_empty_string)]
+    pub bucket: String,
+    #[default(String::new())]
+    #[merge(strategy = overwrite_not_empty_string)]
+    pub access_key_id: String,
+    #[default(String::new())]
+    #[merge(strategy = overwrite_not_empty_string)]
+    pub secret_access_key: String, // pragma: allowlist secret
+    #[default(None)]
+    #[merge(strategy = overwrite)]
+    pub region: Option<String>,
+}
+
+impl fmt::Debug for S3StorageConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("S3StorageConfig")
+            .field("endpoint", &self.endpoint)
+            .field("bucket", &self.bucket)
+            .field("access_key_id", &self.access_key_id)
+            .field(
+                "secret_access_key",
+                &secret_for_debug(&self.secret_access_key),
+            )
+            .field("region", &self.region)
+            .finish()
+    }
+}
+
 #[derive(Merge, Debug, Clone, SmartDefault, serde::Deserialize, serde::Serialize)]
 #[serde(default)]
 pub struct StorageConfig {
     #[default("storage/rooms")]
     #[merge(strategy = overwrite_not_empty_string)]
     pub root: String, // pragma: allowlist secret
+    /// 内容存储后端；默认本地文件系统。
+    #[default(StorageBackendKind::Fs)]
+    #[merge(strategy = overwrite)]
+    pub backend: StorageBackendKind,
+    /// S3/R2 连接配置；backend = s3 时必填。
+    #[default(None)]
+    #[merge(strategy = overwrite)]
+    pub s3: Option<S3StorageConfig>,
 }
 
 /// 房间部署策略。
@@ -455,6 +510,7 @@ mod tests {
             },
             storage: StorageConfig {
                 root: "/tmp/storage".into(),
+                ..Default::default()
             },
             room: RoomConfig {
                 defaults: DefaultRoomConfig {

--- a/crates/configrs/src/configs/mod.rs
+++ b/crates/configrs/src/configs/mod.rs
@@ -4,6 +4,7 @@ mod human_duration;
 pub use app::{
     AppConfig, CompressionConfig, CorsConfig, DatabaseConfig, DefaultRoomConfig, GcConfig,
     JwtConfig, LoggingConfig, MiddlewareConfig, RateLimitConfig, RequestIdConfig, RoomConfig,
-    RoomExpiryConfig, SecurityConfig, ServerConfig, StorageConfig, TracingConfig, UploadConfig,
+    RoomExpiryConfig, S3StorageConfig, SecurityConfig, ServerConfig, StorageBackendKind,
+    StorageConfig, TracingConfig, UploadConfig,
 };
 pub use human_duration::HumanDuration;

--- a/crates/configrs/src/lib.rs
+++ b/crates/configrs/src/lib.rs
@@ -5,8 +5,8 @@ use config::{FileFormat, FileSourceFile, builder::DefaultState};
 pub use configs::{
     AppConfig, CompressionConfig, CorsConfig, DatabaseConfig, DefaultRoomConfig, GcConfig,
     HumanDuration, JwtConfig, LoggingConfig, MiddlewareConfig, RateLimitConfig, RequestIdConfig,
-    RoomConfig, RoomExpiryConfig, SecurityConfig, ServerConfig, StorageConfig, TracingConfig,
-    UploadConfig,
+    RoomConfig, RoomExpiryConfig, S3StorageConfig, SecurityConfig, ServerConfig,
+    StorageBackendKind, StorageConfig, TracingConfig, UploadConfig,
 };
 pub use error::{ConfigError, Result};
 use merge::Merge;

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -37,6 +37,45 @@ docker compose -f docker-compose.yml -f docker-compose.postgres.yml up -d --buil
   `ELIZABETH_STORAGE_DIR`。
 - PostgreSQL：使用 `pg_dump` 备份数据库 + 备份 `ELIZABETH_STORAGE_DIR`。
 
+## 对象存储（S3 / R2，可选）
+
+内容默认存放在本地文件系统；可切换到任意 S3 兼容对象存储（AWS S3、
+MinIO、Cloudflare R2）。房间内容经服务端代理存取，桶地址与凭据不外露。
+
+配置文件（`~/.config/elizabeth/config.yaml`）：
+
+```yaml
+app:
+  storage:
+    backend: s3        # fs（默认）| s3
+    s3:
+      endpoint: https://<account>.r2.cloudflarestorage.com
+      bucket: elizabeth
+      access_key_id: "<ACCESS_KEY_ID>"
+      secret_access_key: "<SECRET_ACCESS_KEY>"
+      region: auto     # R2 填 auto；AWS 填如 us-east-1
+```
+
+或使用环境变量：
+
+```bash
+STORAGE_BACKEND=s3
+STORAGE_S3_ENDPOINT=https://<account>.r2.cloudflarestorage.com
+STORAGE_S3_BUCKET=elizabeth
+STORAGE_S3_ACCESS_KEY_ID=<ACCESS_KEY_ID>
+STORAGE_S3_SECRET_ACCESS_KEY=<SECRET_ACCESS_KEY>
+STORAGE_S3_REGION=auto
+```
+
+说明：
+
+- 切换后端只影响新写入的内容；已存量的本地文件继续按原路径读取，
+  不需要迁移即可保持可下载。
+- 分片上传的临时分片始终落在本地暂存目录（预留清理任务负责回收），
+  最终文件才写入对象存储。
+- 备份：`backend: fs` 时备份存储目录；`backend: s3` 时由桶的版本化 /
+  复制策略负责，服务器侧只需备份数据库。
+
 ## 详细版本
 
 - TLS/反向代理/云平台等：`DEPLOYMENT_FULL.md`

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -47,13 +47,13 @@ MinIO、Cloudflare R2）。房间内容经服务端代理存取，桶地址与�
 ```yaml
 app:
   storage:
-    backend: s3        # fs（默认）| s3
+    backend: s3 # fs（默认）| s3
     s3:
       endpoint: https://<account>.r2.cloudflarestorage.com
       bucket: elizabeth
       access_key_id: "<ACCESS_KEY_ID>"
       secret_access_key: "<SECRET_ACCESS_KEY>"
-      region: auto     # R2 填 auto；AWS 填如 us-east-1
+      region: auto # R2 填 auto；AWS 填如 us-east-1
 ```
 
 或使用环境变量：


### PR DESCRIPTION
Closes #197

## 概要

- **流式 `StorageBackend` 抽象**：`exists_key / store_file / read / delete / purge_room` + `unique_key` 唯一化（文件名净化、冲突追加 (N)），替换原 `Vec<u8>` 非流式草案，并删除 upload/put/complete 三处重复的文件名冲突循环。
- **两个实现**：
  - `FsBackend`（默认）：locator = 绝对路径，与历史行为一致，**存量数据零迁移**；
  - `OpendalBackend`：opendal 0.59 S3 服务（AWS S3 / MinIO / Cloudflare R2），locator = 对象 key，读走 `reader → bytes_stream`，写走 `writer` + futures 流拷贝，不整文件进内存。
- **`RouterBackend` 显式 locator 语法**：`/` 开头 = 历史本地路径，永远由 FS 后端解释；其余 = 主后端 key。切换到 S3 后旧内容无需迁移即可继续下载/删除；新内容全部进对象存储。
- **上传链路统一**：multipart / PUT / 分片合并先落预留暂存目录（复用既有预留清理任务的回收机制），成功后经后端原子转正（FS = rename，S3 = 流式上传）；失败路径清理暂存并释放预留额度。删除 / 下载 / 房间 GC 全部改走后端。
- **配置链**：`storage.backend: fs|s3` + `storage.s3{endpoint,bucket,access_key_id,secret_access_key,region}`（secret Debug 脱敏），env 覆盖 `STORAGE_BACKEND` / `STORAGE_S3_ENDPOINT|BUCKET|ACCESS_KEY_ID|SECRET_ACCESS_KEY|REGION`；配置不全启动即失败（fail fast）。
- **分片临时目录策略**：分片暂存始终在服务器本地（预留级临时目录，由既有清理任务回收），只有最终文件进对象存储。

## 测试

- 单测 7 项（`src/tests/storage_backend.rs`，从 inline 测试迁移并扩充）：FS 存取/清理、Opendal key 语义、RouterBackend 新旧 locator 路由、unique_key 净化与冲突、配置选择与 S3 配置缺失校验。
- 集成 1 项（`tests/api_integration/storage_backends.rs`）：注入 Opendal 后端跑完整 HTTP 流程（建房 → multipart 上传 → 下载回读 → PUT 单命令 → 删除 → 404），验证 handler 与后端无关。
- 实测：`STORAGE_BACKEND=s3` 缺配置时启动 fail-fast 且错误信息明确；默认 FS 链路（建房→PUT→下载）冒烟走通。
- 门禁：`cargo fmt --check` / `cargo check --workspace --all-features` / `cargo test --workspace --all-features`（18 套件）/ `cargo clippy --all-targets --all-features -D warnings` / web `typecheck` 全部通过。

## 限制

- 真实 S3/R2 端到端需线上凭据，本次以 opendal 服务注入的集成测试 + 启动校验代替；接入 R2 后建议按 DEPLOYMENT.md 配置做一次真桶验证。
- 存量 FS 内容不做自动迁移到 S3（locator 路由保证可读）；如需批量搬迁可后续加迁移工具。
